### PR TITLE
Change python package name to pangram-sdk

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: release
-      url: https://pypi.org/p/pangram
+      url: https://pypi.org/p/pangram-sdk
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 
@@ -100,7 +100,7 @@ jobs:
 
     environment:
       name: test
-      url: https://test.pypi.org/p/pangram
+      url: https://test.pypi.org/p/pangram-sdk
 
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Installation
 ```
-pip install pangram
+pip install pangram-sdk
 ```
 
 ### Add your API key

--- a/pangram/__init__.py
+++ b/pangram/__init__.py
@@ -1,5 +1,5 @@
 """Defile all variables to be accessible from `import pangram`."""
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 __author__ = "Max Spero"
 __email__ = "max@pangramlabs.com"
 __license__ = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "pangram-sdk"
+name = "pangram"
 version = "0.1.1"
 description = ""
 authors = ["Max Spero <max@pangramlabs.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "pangram"
+name = "pangram-sdk"
 version = "0.1.1"
 description = ""
 authors = ["Max Spero <max@pangramlabs.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pangram"
-version = "0.1.1"
+version = "0.1.2"
 description = ""
 authors = ["Max Spero <max@pangramlabs.com>"]
 readme = "README.md"


### PR DESCRIPTION
Opened an issue to claim `pangram` as a package name. Until then, we will use `pangram-sdk`.

Issue: https://github.com/pypi/support/issues/4254