### PR TITLE
Propagate API errors instead of attempting to read empty responses field

### DIFF
--- a/pangram/__init__.py
+++ b/pangram/__init__.py
@@ -1,5 +1,5 @@
 """Defile all variables to be accessible from `import pangram`."""
-__version__ = "0.1.2"
+__version__ = "0.1.4"
 __author__ = "Max Spero"
 __email__ = "max@pangramlabs.com"
 __license__ = "MIT"

--- a/pangram/text_classifier.py
+++ b/pangram/text_classifier.py
@@ -2,7 +2,7 @@ import requests
 import os
 from typing import List
 
-SOURCE_VERSION = "python_sdk_0.1.0"
+SOURCE_VERSION = "python_sdk_0.1.4"
 
 API_ENDPOINT = 'https://text.api.pangramlabs.com'
 BATCH_API_ENDPOINT = 'https://text-batch.api.pangramlabs.com'
@@ -48,7 +48,10 @@ class PangramText:
             "source": SOURCE_VERSION,
         }
         response = requests.post(API_ENDPOINT, json=input_json, headers=headers, timeout=90)
-        return response.json()
+        response_json = response.json()
+        if "error" in response_json:
+            raise ValueError(f"Error returned by API: {response_json['error']}")
+        return response_json
 
 
     def batch_predict(self, text_batch: List[str]):
@@ -73,4 +76,9 @@ class PangramText:
             "source": SOURCE_VERSION,
         }
         response = requests.post(BATCH_API_ENDPOINT, json=input_json, headers=headers, timeout=90)
-        return response.json()["responses"]
+        response_json = response.json()
+        if "error" in response_json:
+            raise ValueError(f"Error returned by API: {response_json['error']}")
+        if "responses" not in response_json:
+            raise ValueError(f"Failed to retrieve responses: {response_json}")
+        return response_json["responses"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pangram-sdk"
-version = "0.1.3"
+version = "0.1.4"
 description = ""
 authors = ["Max Spero <max@pangramlabs.com>"]
 readme = "README.md"


### PR DESCRIPTION
* Raises a value error when an error is reached with propagating the error message from the API error.
* This affects input errors and errors related to invalid API keys or running out of credits.