### PR TITLE
Update SDK predictions to async AWS endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,9 +38,9 @@ The SDK is minimal with two main files:
 
 ### API Methods
 
-- `predict(text)` - Main V3 endpoint for AI-assistance detection with segment-level analysis
+- `predict(text)` - Main async AWS endpoint for AI-assistance detection with segment-level analysis
 - `check_plagiarism(text)` - Plagiarism detection against online content database
 
 ### API Configuration
 
-API endpoints are defined as constants at the top of `text_classifier.py`. The SDK uses `requests` for HTTP calls and authenticates via `x-api-key` header.
+API endpoints are defined as constants at the top of `text_classifier.py`. The SDK uses `requests` for HTTP calls and authenticates via `x-api-key` header. The main prediction call submits a task and polls until completion.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Most tests are mocked unit tests. Live plagiarism coverage is skipped unless `PA
 
 **Run a single test:**
 ```bash
-poetry run python -m unittest tests/pangram_test.py::TestPredict::test_predict
+poetry run python -m unittest tests.pangram_test.TestPredict.test_predict
 ```
 
 **Build documentation:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,10 +13,11 @@ This is the official Python SDK for the Pangram Labs API, which provides AI-gene
 poetry install
 ```
 
-**Run tests (requires PANGRAM_API_KEY environment variable):**
+**Run tests:**
 ```bash
 poetry run python -m unittest tests/pangram_test.py
 ```
+Most tests are mocked unit tests. Live plagiarism coverage is skipped unless `PANGRAM_API_KEY` is set.
 
 **Run a single test:**
 ```bash
@@ -38,7 +39,7 @@ The SDK is minimal with two main files:
 
 ### API Methods
 
-- `predict(text)` - Main async AWS endpoint for AI-assistance detection with segment-level analysis
+- `predict(text)` - Main async inference endpoint for AI-assistance detection with segment-level analysis
 - `check_plagiarism(text)` - Plagiarism detection against online content database
 
 ### API Configuration

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pangram_client = Pangram(api_key=my_api_key)
 
 ### Make a request
 
-Main prediction method (V3 - AI-assistance detection and segment-level analysis):
+Main prediction method (AI-assistance detection and segment-level analysis):
 ```
 from pangram import Pangram
 pangram_client = Pangram()
@@ -41,6 +41,7 @@ for window in result['windows']:
     ai_assistance_score = window['ai_assistance_score']
     confidence = window['confidence']  # "High", "Medium", "Low"
 ```
+`predict()` submits to Pangram's async AWS inference API and waits for the result before returning.
 
 Short prediction (scans first ~400 words of text, returns a single AI likelihood prediction):
 ```
@@ -59,13 +60,5 @@ Install docs dependencies and build:
 poetry install --with docs
 cd docs && make html
 ```
-
-### Deprecated Methods
-
-The following methods are deprecated and will be removed by April 1st, 2026:
-
-- `predict_extended()` - Use `predict()` instead
-- `batch_predict()` - Use `predict()` instead
-- `predict_sliding_window()` - Use `predict()` instead
 
 Questions? Email [support@pangram.com](mailto:support@pangram.com)!

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ from pangram import Pangram
 pangram_client = Pangram()
 
 result = pangram_client.predict(text)
-task_id = result['task_id']
 stage = result['stage']  # "STAGE_SUCCESS" after predict() completes.
 
 # Analysis with AI-assistance detection.
@@ -45,6 +44,7 @@ for window in result['windows']:
     confidence = window['confidence']  # "High", "Medium", "Low"
 ```
 `predict()` submits to Pangram's async inference API and waits for the result before returning.
+Use `predict(text, public_dashboard_link=True)` or `predict_with_dashboard_link(text)` to include a `dashboard_link` in the completed result.
 
 ### Building Documentation
 

--- a/README.md
+++ b/README.md
@@ -43,16 +43,6 @@ for window in result['windows']:
 ```
 `predict()` submits to Pangram's async AWS inference API and waits for the result before returning.
 
-Short prediction (scans first ~400 words of text, returns a single AI likelihood prediction):
-```
-from pangram import Pangram
-pangram_client = Pangram()
-
-result = pangram_client.predict_short(text)
-# Score in range [0, 1] where 0 is human-written and 1 is AI-generated.
-score = result['ai_likelihood']
-```
-
 ### Building Documentation
 
 Install docs dependencies and build:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ from pangram import Pangram
 pangram_client = Pangram()
 
 result = pangram_client.predict(text)
-# Analysis with AI-assistance detection
+task_id = result['task_id']
+stage = result['stage']  # "STAGE_SUCCESS" after predict() completes.
+
+# Analysis with AI-assistance detection.
 fraction_ai = result['fraction_ai']
 fraction_ai_assisted = result['fraction_ai_assisted']
 fraction_human = result['fraction_human']
@@ -41,7 +44,7 @@ for window in result['windows']:
     ai_assistance_score = window['ai_assistance_score']
     confidence = window['confidence']  # "High", "Medium", "Low"
 ```
-`predict()` submits to Pangram's async AWS inference API and waits for the result before returning.
+`predict()` submits to Pangram's async inference API and waits for the result before returning.
 
 ### Building Documentation
 

--- a/docs/api/pangram.rst
+++ b/docs/api/pangram.rst
@@ -6,6 +6,5 @@ pangram.text\_classifier module
 
 .. automodule:: pangram.text_classifier
    :members:
-   :exclude-members: predict_extended, predict_sliding_window
    :undoc-members:
    :show-inheritance:

--- a/docs/api/pangram.rst
+++ b/docs/api/pangram.rst
@@ -6,5 +6,6 @@ pangram.text\_classifier module
 
 .. automodule:: pangram.text_classifier
    :members:
+   :exclude-members: predict_extended, predict_sliding_window
    :undoc-members:
    :show-inheritance:

--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -7,7 +7,6 @@ Poll the task endpoint until the stage is ``STAGE_SUCCESS`` or ``STAGE_FAILED``.
 .. http:post:: https://text.external-api.pangram.com/task
 
   :<json string text: The input text to analyze with Pangram.
-  :<json integer priority: Optional task priority. Defaults to 1.
   :<json boolean public_dashboard_link: Whether to include a public dashboard link in the completed response. Defaults to false.
   :>json string task_id: The ID of the async inference task.
 
@@ -26,7 +25,6 @@ Poll the task endpoint until the stage is ``STAGE_SUCCESS`` or ``STAGE_FAILED``.
 
     {
       "text": "<text>",
-      "priority": 1,
       "public_dashboard_link": false
     }
 
@@ -40,7 +38,6 @@ Poll the task endpoint until the stage is ``STAGE_SUCCESS`` or ``STAGE_FAILED``.
 
     {
       "text": "The text to analyze",
-      "priority": 1,
       "public_dashboard_link": true
     }
 
@@ -129,6 +126,26 @@ Poll the task endpoint until the stage is ``STAGE_SUCCESS`` or ``STAGE_FAILED``.
       ]
     }
 
+  **Failed Response**
+
+  .. code-block:: json
+
+    {
+      "stage": "STAGE_FAILED",
+      "text": "",
+      "version": "",
+      "headline": "preprocessing: Input text contains no valid text after preprocessing",
+      "prediction": "",
+      "prediction_short": "",
+      "fraction_ai": 0.0,
+      "fraction_ai_assisted": 0.0,
+      "fraction_human": 0.0,
+      "num_ai_segments": 0,
+      "num_ai_assisted_segments": 0,
+      "num_human_segments": 0,
+      "windows": []
+    }
+
 Plagiarism Detection API
 ========================
 
@@ -199,6 +216,9 @@ The API may return the following error codes:
 - ``400 Bad Request`` - If the request body is not properly formatted.
 - ``401 Unauthorized`` - If the ``x-api-key`` is missing or invalid.
 - ``402 Payment Required`` - If the account has insufficient credits.
+- ``403 Forbidden`` - If the API key does not own the requested task.
+- ``404 Not Found`` - If the requested task does not exist.
+- ``422 Unprocessable Entity`` - If the input text is invalid.
 - ``429 Too Many Requests`` - If the API key exceeds its configured rate limit.
 - ``500 Internal Server Error`` - If there is an error processing the request.
 

--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -1,104 +1,13 @@
 Inference API
 =============
 
-The Inference API accepts text and returns the completed Pangram analysis.
-
-.. http:post:: https://text.api.pangram.com/v3
-
-  :<json string text: The input text to analyze with Pangram.
-  :<json boolean public_dashboard_link: Whether to include a public dashboard link in the response. Defaults to false.
-  :>json string text: The input text that was analyzed.
-  :>json string version: The API version identifier.
-  :>json string headline: Classification headline summarizing the result.
-  :>json string prediction: Long-form prediction string representing the classification.
-  :>json string prediction_short: Short-form prediction string.
-  :>json float fraction_ai: Fraction of text classified as AI-written (0.0-1.0).
-  :>json float fraction_ai_assisted: Fraction of text classified as AI-assisted (0.0-1.0).
-  :>json float fraction_human: Fraction of text classified as human-written (0.0-1.0).
-  :>json int num_ai_segments: Number of text segments classified as AI.
-  :>json int num_ai_assisted_segments: Number of text segments classified as AI-assisted.
-  :>json int num_human_segments: Number of text segments classified as human.
-  :>json array windows: List of analyzed text windows. Each window includes text, label, ai_assistance_score, confidence, start_index, end_index, word_count, and token_length.
-  :>json string dashboard_link: A link to the dashboard page containing the full classification result. Only present when public_dashboard_link is true.
-
-  **Request Headers**
-
-  .. code-block:: json
-
-    {
-      "Content-Type": "application/json",
-      "x-api-key": "<api-key>"
-    }
-
-  **Request Body**
-
-  .. code-block:: json
-
-    {
-      "text": "<text>"
-    }
-
-  **Example Request**
-
-  .. code-block:: http
-
-    POST https://text.api.pangram.com/v3 HTTP/1.1
-    Content-Type: application/json
-    x-api-key: your_api_key_here
-
-    {
-      "text": "The text to analyze with Pangram"
-    }
-
-  **Example Response**
-
-  .. code-block:: json
-
-    {
-      "text": "The text to analyze with Pangram",
-      "version": "3.0",
-      "headline": "AI Detected",
-      "prediction": "We are confident that this document contains AI-generated or AI-assisted content.",
-      "prediction_short": "Mixed",
-      "fraction_ai": 0.70,
-      "fraction_ai_assisted": 0.20,
-      "fraction_human": 0.10,
-      "num_ai_segments": 7,
-      "num_ai_assisted_segments": 2,
-      "num_human_segments": 1,
-      "windows": [
-        {
-          "text": "The text to analyze",
-          "label": "AI-Generated",
-          "ai_assistance_score": 0.85,
-          "confidence": "High",
-          "start_index": 0,
-          "end_index": 19,
-          "word_count": 4,
-          "token_length": 5
-        },
-        {
-          "text": "with Pangram",
-          "label": "Moderately AI-Assisted",
-          "ai_assistance_score": 0.45,
-          "confidence": "Medium",
-          "start_index": 20,
-          "end_index": 32,
-          "word_count": 2,
-          "token_length": 3
-        }
-      ]
-    }
-
-Async Inference API
-===================
-
-The Async Inference API accepts text, creates a task, and returns a task ID.
+The Inference API accepts text, creates a task, and returns a task ID.
 Poll the task endpoint until the stage is ``STAGE_SUCCESS`` or ``STAGE_FAILED``.
 
 .. http:post:: https://text.external-api.pangram.com/task
 
   :<json string text: The input text to analyze with Pangram.
+  :<json boolean public_dashboard_link: Whether to include a public dashboard link in the completed response. Defaults to false.
   :>json string task_id: The ID of the async inference task.
 
   **Request Headers**
@@ -115,7 +24,8 @@ Poll the task endpoint until the stage is ``STAGE_SUCCESS`` or ``STAGE_FAILED``.
   .. code-block:: json
 
     {
-      "text": "<text>"
+      "text": "<text>",
+      "public_dashboard_link": false
     }
 
   **Example Request**
@@ -127,7 +37,8 @@ Poll the task endpoint until the stage is ``STAGE_SUCCESS`` or ``STAGE_FAILED``.
     x-api-key: your_api_key_here
 
     {
-      "text": "The text to analyze"
+      "text": "The text to analyze",
+      "public_dashboard_link": false
     }
 
   **Example Response**
@@ -154,6 +65,7 @@ Poll the task endpoint until the stage is ``STAGE_SUCCESS`` or ``STAGE_FAILED``.
   :>json int num_ai_assisted_segments: Number of text segments classified as AI-assisted. Present on success.
   :>json int num_human_segments: Number of text segments classified as human. Present on success.
   :>json array windows: List of analyzed text windows. Each window includes text, label, ai_assistance_score, confidence, start_index, end_index, word_count, and token_length. Present on success.
+  :>json string dashboard_link: A link to the dashboard page containing the full classification result. Present on success when public_dashboard_link is true.
 
   **Request Headers**
 
@@ -189,6 +101,7 @@ Poll the task endpoint until the stage is ``STAGE_SUCCESS`` or ``STAGE_FAILED``.
       "num_ai_segments": 7,
       "num_ai_assisted_segments": 2,
       "num_human_segments": 1,
+      "dashboard_link": "https://www.pangram.com/history/123e4567-e89b-12d3-a456-426614174000",
       "windows": [
         {
           "text": "The text to analyze",

--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -140,7 +140,7 @@ Poll the task endpoint until the stage is ``STAGE_SUCCESS`` or ``STAGE_FAILED``.
 
 .. http:get:: https://text.external-api.pangram.com/task/(string:task_id)
 
-  :>json string task_id: The ID of the async inference task.
+  :>json string task_id: The ID of the async inference task. Present while the task is in progress.
   :>json string stage: Current task stage. Terminal stages are ``STAGE_SUCCESS`` and ``STAGE_FAILED``.
   :>json string text: The input text that was analyzed. Present on success.
   :>json string version: The API version identifier. Present on success.
@@ -177,7 +177,6 @@ Poll the task endpoint until the stage is ``STAGE_SUCCESS`` or ``STAGE_FAILED``.
   .. code-block:: json
 
     {
-      "task_id": "123e4567-e89b-12d3-a456-426614174000",
       "stage": "STAGE_SUCCESS",
       "text": "The text to analyze",
       "version": "3.0",

--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -1,25 +1,13 @@
 Inference API
 =============
 
-The Inference API allows you to submit text and receive an AI likelihood score.
+The Inference API accepts text, creates an async task, and returns a task ID.
+Poll the task endpoint until the stage is ``STAGE_SUCCESS`` or ``STAGE_FAILED``.
 
-.. http:post:: https://text.api.pangram.com/v3
+.. http:post:: https://text-async.aws.pangram.com/task
 
   :<json string text: The input text to analyze with Pangram.
-  :<json boolean public_dashboard_link: Whether to include a public dashboard link in the response. Defaults to False.
-  :>json string text: The input text that was analyzed.
-  :>json string version: The API version identifier.
-  :>json string headline: Classification headline summarizing the result.
-  :>json string prediction: Long-form prediction string representing the classification.
-  :>json string prediction_short: Short-form prediction string.
-  :>json float fraction_ai: Fraction of text classified as AI-written (0.0-1.0).
-  :>json float fraction_ai_assisted: Fraction of text classified as AI-assisted (0.0-1.0).
-  :>json float fraction_human: Fraction of text classified as human-written (0.0-1.0).
-  :>json int num_ai_segments: Number of text segments classified as AI.
-  :>json int num_ai_assisted_segments: Number of text segments classified as AI-assisted.
-  :>json int num_human_segments: Number of text segments classified as human.
-  :>json array windows: List of text segments (windows) analyzed individually. Each window contains the window text, label (descriptive classification like "AI-Generated", "Moderately AI-Assisted"), ai_assistance_score (float between 0 and 1, where 0 means no AI assistance and 1.0 means AI-generated), confidence (string like "High", "Medium", "Low"), start_index, end_index, word_count, and token_length.
-  :>json string dashboard_link: A link to the dashboard page containing the full classification result. Only present when public_dashboard_link is True.
+  :>json string task_id: The ID of the async inference task.
 
   **Request Headers**
 
@@ -42,89 +30,7 @@ The Inference API allows you to submit text and receive an AI likelihood score.
 
   .. code-block:: http
 
-    POST https://text.api.pangram.com/v3 HTTP/1.1
-    Content-Type: application/json
-    x-api-key: your_api_key_here
-
-    {
-      "text": "The text to analyze with V3 classification"
-    }
-
-  **Example Response**
-
-  .. code-block:: json
-
-    {
-      "text": "The text to analyze with V3 classification",
-      "version": "3.0",
-      "headline": "AI Detected",
-      "prediction": "We are confident that this document is a mix of AI-generated, AI-assisted, and human-written content",
-      "prediction_short": "Mixed",
-      "fraction_ai": 0.70,
-      "fraction_ai_assisted": 0.20,
-      "fraction_human": 0.10,
-      "num_ai_segments": 7,
-      "num_ai_assisted_segments": 2,
-      "num_human_segments": 1,
-      "windows": [
-        {
-          "text": "The text to analyze",
-          "label": "AI-Generated",
-          "ai_assistance_score": 0.85,
-          "confidence": "High",
-          "start_index": 0,
-          "end_index": 19,
-          "word_count": 4,
-          "token_length": 5
-        },
-        {
-          "text": "with V3 classification",
-          "label": "Moderately AI-Assisted",
-          "ai_assistance_score": 0.45,
-          "confidence": "Medium",
-          "start_index": 20,
-          "end_index": 49,
-          "word_count": 4,
-          "token_length": 5
-        }
-      ]
-    }
-
-
-.. http:post:: https://text.api.pangram.com
-
-  .. warning::
-     Posting to the root route (/) for this endpoint is deprecated. Use the v3 endpoint to access the latest version of Pangram. This endpoint will be removed by April 1st, 2026.
-
-  :<json string text: The input text to classify.
-  :<json bool return_ai_sentences: (Optional, default is False) If True, then return a list of the most indicative AI sentences.
-  :>json float ai_likelihood: The classification of the text, on a scale from 0.0 (human) to 1.0 (AI).
-  :>json string text: The classified text.
-  :>json string prediction: A string representing the classification.
-  :>json list ai_sentences: If return_ai_sentences was True, then a list of the most indicative AI sentences.
-
-  **Request Headers**
-
-  .. code-block:: json
-
-    {
-      "Content-Type": "application/json",
-      "x-api-key": "<api-key>"
-    }
-
-  **Request Body**
-
-  .. code-block:: json
-
-    {
-      "text": "<text>"
-    }
-
-  **Example Request**
-
-  .. code-block:: http
-
-    POST https://text.api.pangram.com HTTP/1.1
+    POST https://text-async.aws.pangram.com/task HTTP/1.1
     Content-Type: application/json
     x-api-key: your_api_key_here
 
@@ -137,314 +43,118 @@ The Inference API allows you to submit text and receive an AI likelihood score.
   .. code-block:: json
 
     {
+      "task_id": "123e4567-e89b-12d3-a456-426614174000"
+    }
+
+.. http:get:: https://text-async.aws.pangram.com/task/(string:task_id)
+
+  :>json string task_id: The ID of the async inference task.
+  :>json string stage: Current task stage. Terminal stages are ``STAGE_SUCCESS`` and ``STAGE_FAILED``.
+  :>json string text: The input text that was analyzed. Present on success.
+  :>json string version: The API version identifier. Present on success.
+  :>json string headline: Classification headline summarizing the result. Present on success.
+  :>json string prediction: Long-form prediction string representing the classification. Present on success.
+  :>json string prediction_short: Short-form prediction string. Present on success.
+  :>json float fraction_ai: Fraction of text classified as AI-written (0.0-1.0). Present on success.
+  :>json float fraction_ai_assisted: Fraction of text classified as AI-assisted (0.0-1.0). Present on success.
+  :>json float fraction_human: Fraction of text classified as human-written (0.0-1.0). Present on success.
+  :>json float fraction_mixed: Fraction of text classified as mixed. Present on success.
+  :>json float avg_ai_likelihood: Average AI likelihood across analyzed windows. Present on success.
+  :>json object fraction_breakdown: Confidence-level fraction breakdown. Present on success.
+  :>json int num_ai_segments: Number of text segments classified as AI. Present on success.
+  :>json int num_ai_assisted_segments: Number of text segments classified as AI-assisted. Present on success.
+  :>json int num_human_segments: Number of text segments classified as human. Present on success.
+  :>json array window_indices: Start/end character indices for each analyzed window. Present on success.
+  :>json array windows: List of analyzed text windows. Each window includes text, ai_likelihood, label, confidence, start_index, end_index, word_count, token_length, and editlens metadata.
+
+  **Request Headers**
+
+  .. code-block:: json
+
+    {
+      "x-api-key": "<api-key>"
+    }
+
+  **In-Progress Response**
+
+  .. code-block:: json
+
+    {
+      "task_id": "123e4567-e89b-12d3-a456-426614174000",
+      "stage": "STAGE_PREPROCESSING"
+    }
+
+  **Success Response**
+
+  .. code-block:: json
+
+    {
+      "task_id": "123e4567-e89b-12d3-a456-426614174000",
+      "stage": "STAGE_SUCCESS",
       "text": "The text to analyze",
-      "prediction": "Likely AI",
-      "ai_likelihood": 0.92
-    }
-
-.. http:post:: https://text-batch.api.pangram.com
-
-  .. warning::
-     This endpoint is deprecated. Use the v3 endpoint to access the latest version of Pangram. This endpoint will be removed by April 1st, 2026.
-
-  :<json array text: An array of input texts to classify.
-  :>json array responses: The classification results as a list, each item containing "text", "ai_likelihood", and "prediction". Each item in the array is the same as a response from a single text prediction.
-
-  **Batch Inference**
-
-    **Request Headers**
-
-    .. code-block:: json
-
-      {
-        "Content-Type": "application/json",
-        "x-api-key": "<api-key>"
-      }
-
-    **Request Body**
-
-    .. code-block:: json
-
-      {
-        "text": ["<text1>", "<text2>", "..."]
-      }
-
-    **Example Request**
-
-    .. code-block:: http
-
-      POST https://text-batch.api.pangram.com HTTP/1.1
-      Content-Type: application/json
-      x-api-key: your_api_key_here
-
-      {
-        "text": ["The first text to analyze", "The second text to analyze"]
-      }
-
-    **Example Response**
-
-    .. code-block:: json
-
-      {
-        "responses": [
-          {
-            "text": "The first text to analyze",
-            "prediction": "Likely AI",
-            "ai_likelihood": 0.92
-          },
-          {
-            "text": "The second text to analyze",
-            "prediction": "Possibly AI",
-            "ai_likelihood": 0.58
-          }
-        ]
-      }
-
-.. http:post:: https://text-sliding.api.pangram.com
-
-  .. warning::
-     This endpoint is deprecated. Use the v3 endpoint to access the latest version of Pangram. This endpoint will be removed by April 1st, 2026.
-
-  :<json string text: The input text to segment into windows and classify.
-  :<json bool return_ai_sentences: (Optional, default is False) If True, then return a list of the most indicative AI sentences.
-  :>json string text: The classified text.
-  :>json float ai_likelihood: The classification of the text, on a scale from 0.0 (human) to 1.0 (AI).
-  :>json float max_ai_likelihood: The maximum AI likelihood score among all windows.
-  :>json float avg_ai_likelihood: The average AI likelihood score among all windows.
-  :>json string prediction: A string representing the classification.
-  :>json string short_prediction: A short string representing the classification ("AI", "Human", "Mixed").
-  :>json float fraction_ai_content: The fraction of windows that are classified as AI.
-  :>json array windows: A list of windows and their individual classifications. Each object in the array is the response from a single text prediction.
-  :>json list ai_sentences: If return_ai_sentences was True, then a list of the most indicative AI sentences.
-
-  **Request Headers**
-
-  .. code-block:: json
-
-    {
-      "Content-Type": "application/json",
-      "x-api-key": "<api-key>"
-    }
-
-  **Request Body**
-
-  .. code-block:: json
-
-    {
-      "text": "<text>"
-    }
-
-  **Example Request**
-
-  .. code-block:: http
-
-    POST https://text.api.pangram.com HTTP/1.1
-    Content-Type: application/json
-    x-api-key: your_api_key_here
-
-    {
-      "text": "Extremely long text."
-    }
-
-  **Example Response**
-
-  .. code-block:: json
-
-    {
-      "text": "Extremely long text.",
-      "prediction": "Highly likely AI",
-      "ai_likelihood": 1.0,
-      "max_ai_likelihood": 1.0,
-      "avg_ai_likelihood": 0.6,
-      "fraction_ai_content": 0.5,
-      "windows": [
-        {
-          "text": "Extremely long",
-          "ai_likelihood": 1.0,
-          "prediction": "Highly likely AI"
-        },
-        {
-          "text": "long text.",
-          "ai_likelihood": 0.2,
-          "prediction": "Unlikely AI"
-        }
-      ]
-    }
-
-.. http:post:: https://dashboard-text.api.pangram.com
-
-  .. warning::
-     This endpoint is deprecated. Use the v3 endpoint to access the latest version of Pangram. This endpoint will be removed by April 1st, 2026.
-
-  :<json string text: The input text to classify.
-  :>json float ai_likelihood: The classification of the text, on a scale from 0.0 (human) to 1.0 (AI).
-  :>json string prediction: A string representing the classification.
-  :>json string short_prediction: A short string representing the classification ("AI", "Human", "Mixed").
-  :>json string dashboard_link: A link to the dashboard page containing the full classification result.
-  :>json float fraction_ai_content: The fraction of windows that are classified as AI.
-  :>json float max_ai_likelihood: The maximum AI likelihood score among all windows.
-  :>json float avg_ai_likelihood: The average AI likelihood score among all windows.
-  :>json array windows: A list of windows and their individual classifications. Each object in the array is the response from a single text prediction.
-
-  **Request Headers**
-
-  .. code-block:: json
-
-    {
-      "Content-Type": "application/json",
-      "x-api-key": "<api-key>"
-    }
-
-  **Request Body**
-
-  .. code-block:: json
-
-    {
-      "text": "<text>"
-    }
-
-  **Example Request**
-
-  .. code-block:: http
-
-    POST https://text.api.pangram.com HTTP/1.1
-    Content-Type: application/json
-    x-api-key: your_api_key_here
-
-    {
-      "text": "Extremely long text."
-    }
-
-  **Example Response**
-
-  .. code-block:: json
-
-    {
-      "text": "Extremely long text.",
-      "prediction": "Highly likely AI",
-      "ai_likelihood": 1.0,
-      "dashboard_link": "https://www.pangram.com/history/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-      "max_ai_likelihood": 1.0,
-      "avg_ai_likelihood": 0.6,
-      "fraction_ai_content": 0.5,
-      "windows": [
-        {
-          "text": "Extremely long",
-          "ai_likelihood": 1.0,
-          "prediction": "Highly likely AI"
-        },
-        {
-          "text": "long text.",
-          "ai_likelihood": 0.2,
-          "prediction": "Unlikely AI"
-        }
-      ]
-    }
-
-.. http:post:: https://text-extended.api.pangram.com
-
-  .. warning::
-     This endpoint is deprecated. Use the v3 endpoint to access the latest version of Pangram. This endpoint will be removed by April 1st, 2026.
-
-  :<json string text: The input text to classify with extended analysis.
-  :<json boolean dashboard: Optional flag to enable dashboard integration (default: false).
-  :<json boolean is_public: Optional flag to control visibility in dashboard (default: true).
-  :>json string text: The input text that was analyzed.
-  :>json float avg_ai_likelihood: Weighted average AI likelihood score across all windows.
-  :>json float max_ai_likelihood: Maximum AI likelihood score among all windows.
-  :>json string prediction: Long-form prediction string representing the classification.
-  :>json string prediction_short: Short-form prediction string ("AI", "Human", "Mixed").
-  :>json string headline: Classification headline summarizing the result.
-  :>json array windows: List of text segments (windows) analyzed individually. Each window contains text, ai_likelihood, label (str), confidence (str), start_index, end_index, and word_count.
-  :>json array window_likelihoods: AI likelihood scores for each window (list of values from 0.0 to 1.0)
-  :>json array window_indices: Indices indicating the position of each window in the original text (list of tuples (start_char_index, end_char_index))
-  :>json float fraction_human: Fraction of text classified as human-written (0.0-1.0).
-  :>json float fraction_ai: Fraction of text classified as AI-written (0.0-1.0).
-  :>json float fraction_mixed: Fraction of text classified as mixed content (0.0-1.0).
-  :>json object metadata: Additional metadata about the analysis.
-  :>json string version: Analysis version identifier ("adaptive_boundaries").
-  :>json string dashboard_link: Optional dashboard link (only present when dashboard=true). is_public controls visibility of dashboard link, to only your account or all users. 
-
-  **Request Headers**
-
-  .. code-block:: json
-
-    {
-      "Content-Type": "application/json",
-      "x-api-key": "<api-key>"
-    }
-
-  **Request Body**
-
-  .. code-block:: json
-
-    {
-      "text": "<text>",
-      "dashboard": false,
-      "is_public": true
-    }
-
-  **Example Request**
-
-  .. code-block:: http
-
-    POST https://text-extended.api.pangram.com HTTP/1.1
-    Content-Type: application/json
-    x-api-key: your_api_key_here
-
-    {
-      "text": "The text to analyze with extended classification",
-      "dashboard": true,
-      "is_public": true
-    }
-
-  **Example Response**
-
-  .. code-block:: json
-
-    {
-      "text": "The text to analyze with extended classification",
-      "avg_ai_likelihood": 0.75,
-      "max_ai_likelihood": 0.92,
-      "prediction": "Primarily AI-generated, or heavily AI-assisted",
-      "prediction_short": "AI",
+      "version": "3.0",
       "headline": "AI Detected",
+      "prediction": "We are confident that this document contains AI-generated or AI-assisted content.",
+      "prediction_short": "Mixed",
+      "fraction_ai": 0.70,
+      "fraction_ai_assisted": 0.20,
+      "fraction_human": 0.10,
+      "fraction_mixed": 0.00,
+      "avg_ai_likelihood": 0.78,
+      "fraction_breakdown": {
+        "ai": {
+          "high-confidence": 0.50,
+          "medium-confidence": 0.20,
+          "low-confidence": 0.00
+        },
+        "ai-assisted": {
+          "lightly": 0.10,
+          "moderately": 0.10
+        },
+        "human": {
+          "high-confidence": 0.10,
+          "medium-confidence": 0.00,
+          "low-confidence": 0.00
+        }
+      },
+      "num_ai_segments": 7,
+      "num_ai_assisted_segments": 2,
+      "num_human_segments": 1,
+      "window_indices": [[0, 19], [20, 49]],
       "windows": [
         {
           "text": "The text to analyze",
           "ai_likelihood": 0.85,
-          "label": "AI",
-          "confidence": "Medium",
+          "label": "AI-Generated",
+          "confidence": "High",
           "start_index": 0,
           "end_index": 19,
-          "word_count": 4
+          "word_count": 4,
+          "token_length": 5,
+          "editlens": {
+            "prediction_text": "AI-Generated"
+          }
         },
         {
-          "text": "with extended classification",
-          "ai_likelihood": 0.65,
-          "label": "AI",
-          "confidence": "Low",
+          "text": "with classification",
+          "ai_likelihood": 0.45,
+          "label": "Moderately AI-Assisted",
+          "confidence": "Medium",
           "start_index": 20,
-          "end_index": 47,
-          "word_count": 3
+          "end_index": 49,
+          "word_count": 2,
+          "token_length": 3,
+          "editlens": {
+            "prediction_text": "Moderately AI-Assisted"
+          }
         }
-      ],
-      "window_likelihoods": [0.85, 0.65],
-      "window_indices": [[0, 19], [20, 47]],
-      "fraction_human": 0.25,
-      "fraction_ai": 0.70,
-      "fraction_mixed": 0.05,
-      "metadata": {
-        "request_id": "123e4567-e89b-12d3-a456-426614174000"
-      },
-      "version": "adaptive_boundaries",
-      "dashboard_link": "https://www.pangram.com/history/123e4567-e89b-12d3-a456-426614174000"
+      ]
     }
 
 Plagiarism Detection API
 ========================
 
-The Plagiarism Detection API allows you to check text for potential plagiarism by comparing it against a vast database of online content.
+The Plagiarism Detection API checks text for potential plagiarism by comparing it against online content.
 
 .. http:post:: https://plagiarism.api.pangram.com
 
@@ -508,8 +218,10 @@ The Plagiarism Detection API allows you to check text for potential plagiarism b
 
 The API may return the following error codes:
 
-- `400 Bad Request` - If the request body is not properly formatted.
-- `401 Unauthorized` - If the `x-api-key` is missing, invalid, or does not have enough credits to process the request.
-- `500 Internal Server Error` - If there is an error processing the request.
+- ``400 Bad Request`` - If the request body is not properly formatted.
+- ``401 Unauthorized`` - If the ``x-api-key`` is missing or invalid.
+- ``402 Payment Required`` - If the account has insufficient credits.
+- ``429 Too Many Requests`` - If the API key exceeds its configured rate limit.
+- ``500 Internal Server Error`` - If there is an error processing the request.
 
 Please reach out at `support@pangram.com <mailto:support@pangram.com>`_ if you are running into errors with your requests.

--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -1,10 +1,102 @@
 Inference API
 =============
 
-The Inference API accepts text, creates an async task, and returns a task ID.
+The Inference API accepts text and returns the completed Pangram analysis.
+
+.. http:post:: https://text.api.pangram.com/v3
+
+  :<json string text: The input text to analyze with Pangram.
+  :<json boolean public_dashboard_link: Whether to include a public dashboard link in the response. Defaults to false.
+  :>json string text: The input text that was analyzed.
+  :>json string version: The API version identifier.
+  :>json string headline: Classification headline summarizing the result.
+  :>json string prediction: Long-form prediction string representing the classification.
+  :>json string prediction_short: Short-form prediction string.
+  :>json float fraction_ai: Fraction of text classified as AI-written (0.0-1.0).
+  :>json float fraction_ai_assisted: Fraction of text classified as AI-assisted (0.0-1.0).
+  :>json float fraction_human: Fraction of text classified as human-written (0.0-1.0).
+  :>json int num_ai_segments: Number of text segments classified as AI.
+  :>json int num_ai_assisted_segments: Number of text segments classified as AI-assisted.
+  :>json int num_human_segments: Number of text segments classified as human.
+  :>json array windows: List of analyzed text windows. Each window includes text, label, ai_assistance_score, confidence, start_index, end_index, word_count, and token_length.
+  :>json string dashboard_link: A link to the dashboard page containing the full classification result. Only present when public_dashboard_link is true.
+
+  **Request Headers**
+
+  .. code-block:: json
+
+    {
+      "Content-Type": "application/json",
+      "x-api-key": "<api-key>"
+    }
+
+  **Request Body**
+
+  .. code-block:: json
+
+    {
+      "text": "<text>"
+    }
+
+  **Example Request**
+
+  .. code-block:: http
+
+    POST https://text.api.pangram.com/v3 HTTP/1.1
+    Content-Type: application/json
+    x-api-key: your_api_key_here
+
+    {
+      "text": "The text to analyze with Pangram"
+    }
+
+  **Example Response**
+
+  .. code-block:: json
+
+    {
+      "text": "The text to analyze with Pangram",
+      "version": "3.0",
+      "headline": "AI Detected",
+      "prediction": "We are confident that this document contains AI-generated or AI-assisted content.",
+      "prediction_short": "Mixed",
+      "fraction_ai": 0.70,
+      "fraction_ai_assisted": 0.20,
+      "fraction_human": 0.10,
+      "num_ai_segments": 7,
+      "num_ai_assisted_segments": 2,
+      "num_human_segments": 1,
+      "windows": [
+        {
+          "text": "The text to analyze",
+          "label": "AI-Generated",
+          "ai_assistance_score": 0.85,
+          "confidence": "High",
+          "start_index": 0,
+          "end_index": 19,
+          "word_count": 4,
+          "token_length": 5
+        },
+        {
+          "text": "with Pangram",
+          "label": "Moderately AI-Assisted",
+          "ai_assistance_score": 0.45,
+          "confidence": "Medium",
+          "start_index": 20,
+          "end_index": 32,
+          "word_count": 2,
+          "token_length": 3
+        }
+      ]
+    }
+
+Async Inference API
+===================
+
+The Async Inference API accepts text, creates a task, and returns a task ID.
 Poll the task endpoint until the stage is ``STAGE_SUCCESS`` or ``STAGE_FAILED``.
 
-.. http:post:: https://text-async.aws.pangram.com/task
+.. http:post:: https://text.external-api.pangram.com/task
 
   :<json string text: The input text to analyze with Pangram.
   :>json string task_id: The ID of the async inference task.
@@ -30,7 +122,7 @@ Poll the task endpoint until the stage is ``STAGE_SUCCESS`` or ``STAGE_FAILED``.
 
   .. code-block:: http
 
-    POST https://text-async.aws.pangram.com/task HTTP/1.1
+    POST https://text.external-api.pangram.com/task HTTP/1.1
     Content-Type: application/json
     x-api-key: your_api_key_here
 
@@ -46,7 +138,7 @@ Poll the task endpoint until the stage is ``STAGE_SUCCESS`` or ``STAGE_FAILED``.
       "task_id": "123e4567-e89b-12d3-a456-426614174000"
     }
 
-.. http:get:: https://text-async.aws.pangram.com/task/(string:task_id)
+.. http:get:: https://text.external-api.pangram.com/task/(string:task_id)
 
   :>json string task_id: The ID of the async inference task.
   :>json string stage: Current task stage. Terminal stages are ``STAGE_SUCCESS`` and ``STAGE_FAILED``.
@@ -58,14 +150,10 @@ Poll the task endpoint until the stage is ``STAGE_SUCCESS`` or ``STAGE_FAILED``.
   :>json float fraction_ai: Fraction of text classified as AI-written (0.0-1.0). Present on success.
   :>json float fraction_ai_assisted: Fraction of text classified as AI-assisted (0.0-1.0). Present on success.
   :>json float fraction_human: Fraction of text classified as human-written (0.0-1.0). Present on success.
-  :>json float fraction_mixed: Fraction of text classified as mixed. Present on success.
-  :>json float avg_ai_likelihood: Average AI likelihood across analyzed windows. Present on success.
-  :>json object fraction_breakdown: Confidence-level fraction breakdown. Present on success.
   :>json int num_ai_segments: Number of text segments classified as AI. Present on success.
   :>json int num_ai_assisted_segments: Number of text segments classified as AI-assisted. Present on success.
   :>json int num_human_segments: Number of text segments classified as human. Present on success.
-  :>json array window_indices: Start/end character indices for each analyzed window. Present on success.
-  :>json array windows: List of analyzed text windows. Each window includes text, ai_likelihood, label, confidence, start_index, end_index, word_count, token_length, and editlens metadata.
+  :>json array windows: List of analyzed text windows. Each window includes text, label, ai_assistance_score, confidence, start_index, end_index, word_count, and token_length. Present on success.
 
   **Request Headers**
 
@@ -99,54 +187,29 @@ Poll the task endpoint until the stage is ``STAGE_SUCCESS`` or ``STAGE_FAILED``.
       "fraction_ai": 0.70,
       "fraction_ai_assisted": 0.20,
       "fraction_human": 0.10,
-      "fraction_mixed": 0.00,
-      "avg_ai_likelihood": 0.78,
-      "fraction_breakdown": {
-        "ai": {
-          "high-confidence": 0.50,
-          "medium-confidence": 0.20,
-          "low-confidence": 0.00
-        },
-        "ai-assisted": {
-          "lightly": 0.10,
-          "moderately": 0.10
-        },
-        "human": {
-          "high-confidence": 0.10,
-          "medium-confidence": 0.00,
-          "low-confidence": 0.00
-        }
-      },
       "num_ai_segments": 7,
       "num_ai_assisted_segments": 2,
       "num_human_segments": 1,
-      "window_indices": [[0, 19], [20, 49]],
       "windows": [
         {
           "text": "The text to analyze",
-          "ai_likelihood": 0.85,
           "label": "AI-Generated",
+          "ai_assistance_score": 0.85,
           "confidence": "High",
           "start_index": 0,
           "end_index": 19,
           "word_count": 4,
-          "token_length": 5,
-          "editlens": {
-            "prediction_text": "AI-Generated"
-          }
+          "token_length": 5
         },
         {
           "text": "with classification",
-          "ai_likelihood": 0.45,
           "label": "Moderately AI-Assisted",
+          "ai_assistance_score": 0.45,
           "confidence": "Medium",
           "start_index": 20,
           "end_index": 49,
           "word_count": 2,
-          "token_length": 3,
-          "editlens": {
-            "prediction_text": "Moderately AI-Assisted"
-          }
+          "token_length": 3
         }
       ]
     }

--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -7,6 +7,7 @@ Poll the task endpoint until the stage is ``STAGE_SUCCESS`` or ``STAGE_FAILED``.
 .. http:post:: https://text.external-api.pangram.com/task
 
   :<json string text: The input text to analyze with Pangram.
+  :<json integer priority: Optional task priority. Defaults to 1.
   :<json boolean public_dashboard_link: Whether to include a public dashboard link in the completed response. Defaults to false.
   :>json string task_id: The ID of the async inference task.
 
@@ -25,6 +26,7 @@ Poll the task endpoint until the stage is ``STAGE_SUCCESS`` or ``STAGE_FAILED``.
 
     {
       "text": "<text>",
+      "priority": 1,
       "public_dashboard_link": false
     }
 
@@ -38,7 +40,8 @@ Poll the task endpoint until the stage is ``STAGE_SUCCESS`` or ``STAGE_FAILED``.
 
     {
       "text": "The text to analyze",
-      "public_dashboard_link": false
+      "priority": 1,
+      "public_dashboard_link": true
     }
 
   **Example Response**

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -35,6 +35,7 @@ Make a request
 Main prediction
 ~~~~~~~~~~~~~~~
 Returns detailed analysis with AI-assistance detection and segment-level metrics
+The SDK submits to Pangram's async AWS inference API and waits for the completed result.
 
 .. code:: python
 
@@ -42,7 +43,7 @@ Returns detailed analysis with AI-assistance detection and segment-level metrics
 
     pangram_client = Pangram()
     result = pangram_client.predict(text)
-    # V3 analysis with AI-assistance detection
+    # Analysis with AI-assistance detection
     fraction_ai = result['fraction_ai']
     fraction_ai_assisted = result['fraction_ai_assisted']
     fraction_human = result['fraction_human']
@@ -93,12 +94,3 @@ The plagiarism detection response includes
 - Total number of sentences checked
 - List of plagiarized sentences
 - Percentage of text that was plagiarized
-
-Deprecated Methods
-~~~~~~~~~~~~~~~~~~~
-
-The following methods are deprecated and will be removed by April 1st, 2026:
-
-- ``predict_extended()`` - Use ``predict()`` instead
-- ``batch_predict()`` - Use ``predict()`` instead
-- ``predict_sliding_window()`` - Use ``predict()`` instead

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -54,19 +54,6 @@ The SDK submits to Pangram's async AWS inference API and waits for the completed
         ai_assistance_score = window['ai_assistance_score']
         confidence = window['confidence']
 
-Short prediction
-~~~~~~~~~~~~~~~~~
-Single Pangram model prediction, cuts off text at 512 tokens
-
-.. code:: python
-
-    from pangram import Pangram
-
-    pangram_client = Pangram()
-    result = pangram_client.predict_short(text)
-    # Score in range [0, 1] where 0 is human-written and 1 is AI-generated.
-    score = result['ai_likelihood']
-
 Check for Plagiarism
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -35,7 +35,7 @@ Make a request
 Main prediction
 ~~~~~~~~~~~~~~~
 Returns detailed analysis with AI-assistance detection and segment-level metrics
-The SDK submits to Pangram's async AWS inference API and waits for the completed result.
+The SDK submits to Pangram's async inference API and waits for the completed result.
 
 .. code:: python
 
@@ -43,7 +43,10 @@ The SDK submits to Pangram's async AWS inference API and waits for the completed
 
     pangram_client = Pangram()
     result = pangram_client.predict(text)
-    # Analysis with AI-assistance detection
+    task_id = result['task_id']
+    stage = result['stage']  # "STAGE_SUCCESS" after predict() completes.
+
+    # Analysis with AI-assistance detection.
     fraction_ai = result['fraction_ai']
     fraction_ai_assisted = result['fraction_ai_assisted']
     fraction_human = result['fraction_human']

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -43,7 +43,6 @@ The SDK submits to Pangram's async inference API and waits for the completed res
 
     pangram_client = Pangram()
     result = pangram_client.predict(text)
-    task_id = result['task_id']
     stage = result['stage']  # "STAGE_SUCCESS" after predict() completes.
 
     # Analysis with AI-assistance detection.

--- a/pangram/__init__.py
+++ b/pangram/__init__.py
@@ -1,5 +1,5 @@
 """Defile all variables to be accessible from `import pangram`."""
-__version__ = "0.1.11"
+__version__ = "0.2.0"
 __author__ = "Max Spero"
 __email__ = "max@pangram.com"
 __license__ = "MIT"

--- a/pangram/text_classifier.py
+++ b/pangram/text_classifier.py
@@ -7,7 +7,6 @@ from typing import List, Dict, Optional
 SOURCE_VERSION = "python_sdk_0.1.11"
 
 API_ENDPOINT = 'https://text-async.aws.pangram.com'
-PREDICT_SHORT_API_ENDPOINT = 'https://text.api.pangram.com/v3'
 BATCH_API_ENDPOINT = 'https://text-batch.api.pangramlabs.com'
 SLIDING_WINDOW_API_ENDPOINT = 'https://text-sliding.api.pangramlabs.com'
 PLAGIARISM_API_ENDPOINT = 'https://plagiarism.api.pangram.com'
@@ -147,29 +146,6 @@ class PangramText:
             for key, value in normalized.items()
             if value is not None
         }
-
-    def predict_short(self, text: str):
-        """
-        Classify text as AI- or human-written using the short endpoint.
-
-        Sends a request to the Pangram Text API and returns the classification result.
-
-        :param text: The text to be classified.
-        :type text: str
-        :return: The classification result from the API, as a dict with the following fields:
-
-                - text (str): The input text.
-                - ai_likelihood (float): The classification of the text, on a scale from 0.0 (human) to 1.0 (AI).
-                - prediction (str): A string representing the classification.
-        :rtype: dict
-        """
-        input_json = {
-            "text": text,
-            "source": SOURCE_VERSION,
-        }
-        response = requests.post(PREDICT_SHORT_API_ENDPOINT, json=input_json, headers=self._headers(), timeout=90)
-        return self._parse_response_json(response)
-
 
     def predict(
         self,

--- a/pangram/text_classifier.py
+++ b/pangram/text_classifier.py
@@ -1,18 +1,25 @@
 import requests
 import os
+import time
 import warnings
 from typing import List, Dict, Optional
 
 SOURCE_VERSION = "python_sdk_0.1.11"
 
-API_ENDPOINT = 'https://text.api.pangram.com/v3'
+API_ENDPOINT = 'https://text-async.aws.pangram.com'
+PREDICT_SHORT_API_ENDPOINT = 'https://text.api.pangram.com/v3'
 BATCH_API_ENDPOINT = 'https://text-batch.api.pangramlabs.com'
 SLIDING_WINDOW_API_ENDPOINT = 'https://text-sliding.api.pangramlabs.com'
 PLAGIARISM_API_ENDPOINT = 'https://plagiarism.api.pangram.com'
 TEXT_EXTENDED_API_ENDPOINT = 'https://text-extended.api.pangramlabs.com'
+ASYNC_SUCCESS_STAGE = 'STAGE_SUCCESS'
+ASYNC_FAILED_STAGE = 'STAGE_FAILED'
+DEFAULT_PREDICT_TIMEOUT_SECONDS = 300
+DEFAULT_POLL_INTERVAL_SECONDS = 0.5
+REQUEST_TIMEOUT_SECONDS = 10
 
 class PangramText:
-    def __init__(self, api_key: str = None) -> None:
+    def __init__(self, api_key: Optional[str] = None) -> None:
         """
         A classifier for text inputs using the Pangram Labs API.
 
@@ -27,6 +34,119 @@ class PangramText:
         if self.api_key is None:
             raise ValueError("API key is required. Set the environment variable PANGRAM_API_KEY or pass it as an argument to PangramText.")
 
+    def _headers(self) -> Dict[str, str]:
+        return {
+            'Content-Type': 'application/json',
+            'x-api-key': self.api_key,
+        }
+
+    def _request_timeout(self, deadline: float) -> float:
+        remaining = deadline - time.monotonic()
+        return max(0.1, min(REQUEST_TIMEOUT_SECONDS, remaining))
+
+    def _parse_response_json(self, response: requests.Response):
+        if response.status_code != 200:
+            raise ValueError(f"Error returned by API: [{response.status_code}] {response.text}")
+        try:
+            response_json = response.json()
+        except ValueError as exc:
+            raise ValueError(f"Error returned by API: non-JSON response: {response.text}") from exc
+        if isinstance(response_json, dict) and "error" in response_json:
+            raise ValueError(f"Error returned by API: {response_json['error']}")
+        return response_json
+
+    def _submit_prediction_task(self, text: str, deadline: float) -> str:
+        response = requests.post(
+            f"{API_ENDPOINT}/task",
+            json={"text": text},
+            headers=self._headers(),
+            timeout=self._request_timeout(deadline),
+        )
+        response_json = self._parse_response_json(response)
+        if not isinstance(response_json, dict):
+            raise ValueError(f"Error returned by API: invalid task response: {response_json}")
+
+        task_id = response_json.get("task_id")
+        if not isinstance(task_id, str) or not task_id:
+            raise ValueError(f"Error returned by API: missing task_id in response: {response_json}")
+        return task_id
+
+    def _poll_prediction_task(
+        self,
+        task_id: str,
+        deadline: float,
+        timeout: float,
+        poll_interval: float,
+    ) -> Dict:
+        while True:
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"Pangram prediction task {task_id} did not complete within {timeout:.0f}s")
+
+            response = requests.get(
+                f"{API_ENDPOINT}/task/{task_id}",
+                headers=self._headers(),
+                timeout=self._request_timeout(deadline),
+            )
+            response_json = self._parse_response_json(response)
+            if not isinstance(response_json, dict):
+                raise ValueError(f"Error returned by API: invalid task result: {response_json}")
+
+            stage = response_json.get("stage")
+            if stage == ASYNC_SUCCESS_STAGE:
+                return self._normalize_prediction_response(response_json)
+            if stage == ASYNC_FAILED_STAGE:
+                message = response_json.get("headline") or response_json.get("detail") or "task failed"
+                raise ValueError(f"Error returned by API: task {task_id} failed: {message}")
+            if stage is None:
+                raise ValueError(f"Error returned by API: missing stage for task {task_id}")
+
+            sleep_for = min(poll_interval, max(0.0, deadline - time.monotonic()))
+            if sleep_for > 0:
+                time.sleep(sleep_for)
+
+    @staticmethod
+    def _normalize_prediction_response(response_json: Dict) -> Dict:
+        result = dict(response_json)
+        result.pop("task_id", None)
+        result.pop("stage", None)
+
+        windows = result.get("windows")
+        if isinstance(windows, list):
+            result["windows"] = [
+                PangramText._normalize_prediction_window(window)
+                for window in windows
+            ]
+        return result
+
+    @staticmethod
+    def _normalize_prediction_window(window):
+        if not isinstance(window, dict):
+            return window
+
+        editlens = window.get("editlens")
+        label = window.get("label")
+        if isinstance(editlens, dict):
+            label = editlens.get("prediction_text") or label
+
+        ai_assistance_score = window.get("ai_assistance_score")
+        if ai_assistance_score is None:
+            ai_assistance_score = window.get("ai_likelihood")
+
+        normalized = {
+            "text": window.get("text"),
+            "label": label,
+            "ai_assistance_score": ai_assistance_score,
+            "confidence": window.get("confidence"),
+            "start_index": window.get("start_index"),
+            "end_index": window.get("end_index"),
+            "word_count": window.get("word_count"),
+            "token_length": window.get("token_length"),
+        }
+        return {
+            key: value
+            for key, value in normalized.items()
+            if value is not None
+        }
 
     def predict_short(self, text: str):
         """
@@ -43,34 +163,35 @@ class PangramText:
                 - prediction (str): A string representing the classification.
         :rtype: dict
         """
-        headers = {
-            'Content-Type': 'application/json',
-            'x-api-key': self.api_key,
-        }
         input_json = {
             "text": text,
             "source": SOURCE_VERSION,
         }
-        response = requests.post(API_ENDPOINT, json=input_json, headers=headers, timeout=90)
-        if response.status_code != 200:
-            raise ValueError(f"Error returned by API: [{response.status_code}] {response.text}")
-        response_json = response.json()
-        if "error" in response_json:
-            raise ValueError(f"Error returned by API: {response_json['error']}")
-        return response_json
+        response = requests.post(PREDICT_SHORT_API_ENDPOINT, json=input_json, headers=self._headers(), timeout=90)
+        return self._parse_response_json(response)
 
 
-    def predict(self, text: str, public_dashboard_link: bool = False) -> Dict:
+    def predict(
+        self,
+        text: str,
+        public_dashboard_link: bool = False,
+        timeout: float = DEFAULT_PREDICT_TIMEOUT_SECONDS,
+        poll_interval: float = DEFAULT_POLL_INTERVAL_SECONDS,
+    ) -> Dict:
         """
-        Classify text as AI-, AI-assisted, or human-written using the V3 API.
+        Classify text as AI-, AI-assisted, or human-written.
 
-        Sends a request to the Pangram Text API V3 endpoint and returns analysis with windowed results.
-        This endpoint now provides AI-assistance detection in the segment-level analysis.
+        Submits the text to Pangram's async AWS inference endpoint, waits for completion,
+        and returns analysis with windowed results.
 
         :param text: The text to be classified.
         :type text: str
-        :param public_dashboard_link: Whether to include a public dashboard link in the response. Defaults to False.
+        :param public_dashboard_link: Kept for API compatibility. The async inference endpoint returns dashboard links only when supported by the service.
         :type public_dashboard_link: bool
+        :param timeout: Maximum seconds to wait for the async task to complete. Defaults to 300.
+        :type timeout: float
+        :param poll_interval: Seconds to wait between polling attempts. Defaults to 0.5.
+        :type poll_interval: float
         :return: Pangram analysis with AI-assistance detection as a dict with the following fields:
 
                 - text (str): The input text.
@@ -84,7 +205,7 @@ class PangramText:
                 - num_ai_segments (int): Number of text segments classified as AI.
                 - num_ai_assisted_segments (int): Number of text segments classified as AI-assisted.
                 - num_human_segments (int): Number of text segments classified as human.
-                - dashboard_link (str): A link to the dashboard page containing the full classification result. Only present when public_dashboard_link is True.
+                - dashboard_link (str): A link to the dashboard page containing the full classification result, if returned by the service.
                 - windows (list): List of text windows and their classifications. Each window contains:
                     - text (str): The window text.
                     - label (str): Descriptive classification label (e.g., "AI-Generated", "Moderately AI-Assisted").
@@ -96,24 +217,16 @@ class PangramText:
                     - token_length (int): Token length of the window.
         :rtype: Dict
         :raises ValueError: If the API returns an error or if the response is invalid
+        :raises TimeoutError: If the async task does not complete before timeout
         """
-        headers = {
-            'Content-Type': 'application/json',
-            'x-api-key': self.api_key,
-        }
-        input_json = {
-            "text": text,
-            "source": SOURCE_VERSION,
-            "public_dashboard_link": public_dashboard_link,
-        }
+        if timeout <= 0:
+            raise ValueError("timeout must be greater than 0")
+        if poll_interval < 0:
+            raise ValueError("poll_interval cannot be negative")
 
-        response = requests.post(API_ENDPOINT, json=input_json, headers=headers, timeout=90)
-        if response.status_code != 200:
-            raise ValueError(f"Error returned by API: [{response.status_code}] {response.text}")
-        response_json = response.json()
-        if "error" in response_json:
-            raise ValueError(f"Error returned by API: {response_json['error']}")
-        return response_json
+        deadline = time.monotonic() + timeout
+        task_id = self._submit_prediction_task(text, deadline)
+        return self._poll_prediction_task(task_id, deadline, timeout, poll_interval)
 
 
     def batch_predict(self, text_batch: List[str]) -> List[Dict]:
@@ -140,7 +253,7 @@ class PangramText:
         Classify a long document using a sliding window to iterate across the full document.
 
         .. deprecated:: 0.1.8
-           This method is deprecated. Use :meth:`predict` instead for better performance. This method will be removed by April 1st, 2026. 
+           This method is deprecated. Use :meth:`predict` instead.
 
         :param text: The text to be classified.
         :type text: str
@@ -157,7 +270,7 @@ class PangramText:
         :rtype: dict
         """
         warnings.warn(
-            "predict_sliding_window() is deprecated. Use predict() instead to access Pangram's latest model. This method will be removed by April 1st, 2026.",
+            "predict_sliding_window() is deprecated. Use predict() instead.",
             DeprecationWarning,
             stacklevel=2
         )
@@ -180,17 +293,17 @@ class PangramText:
 
     def predict_with_dashboard_link(self, text: str):
         """
-        Classify text as AI- or human-written.
+        Classify text as AI-, AI-assisted, or human-written.
 
-        Sends a request to the Pangram Text API and returns the classification result, along with a
-        link to a dashboard page containing the classification result.
+        Sends a request to the Pangram Text API and returns the classification result.
+        The async inference endpoint returns a dashboard link only when supported by the service.
 
         :param text: The text to be classified.
         :type text: str
         :return: The classification result from the API, as a dict with the following fields:
 
                 - text (string): The classified text.
-                - dashboard_link (string): A link to a dashboard page containing the classification result.
+                - dashboard_link (string): A link to a dashboard page containing the classification result, if returned by the service.
                 - ai_likelihood (float): The classification of the text, on a scale from 0.0 (human) to 1.0 (AI).
                 - max_ai_likelihood (float): The maximum AI likelihood score among all windows.
                 - avg_ai_likelihood (float): The average AI likelihood score among all windows.
@@ -244,7 +357,7 @@ class PangramText:
         Sends a request to the Pangram Text Extended API and returns precise, windowed results using adaptive boundaries 
 
         .. deprecated:: 0.1.11
-           This method is deprecated. Use :meth:`predict` instead for better performance. This method will be removed by April 1st, 2026. 
+           This method is deprecated. Use :meth:`predict` instead.
 
         :param text: The text to be classified.
         :type text: str
@@ -268,7 +381,7 @@ class PangramText:
         :raises ValueError: If the API returns an error or if the response is invalid
         """
         warnings.warn(
-            "predict_extended() is deprecated. Use predict() instead to access Pangram's latest model. This method will be removed by April 1st, 2026.",
+            "predict_extended() is deprecated. Use predict() instead.",
             DeprecationWarning,
             stacklevel=2
         )

--- a/pangram/text_classifier.py
+++ b/pangram/text_classifier.py
@@ -4,7 +4,7 @@ import time
 import warnings
 from typing import List, Dict, Optional
 
-SOURCE_VERSION = "python_sdk_0.1.11"
+SOURCE_VERSION = "python_sdk_0.2.0"
 
 API_ENDPOINT = 'https://text.external-api.pangram.com'
 PLAGIARISM_API_ENDPOINT = 'https://plagiarism.api.pangram.com'
@@ -12,6 +12,7 @@ ASYNC_SUCCESS_STAGE = 'STAGE_SUCCESS'
 ASYNC_FAILED_STAGE = 'STAGE_FAILED'
 DEFAULT_PREDICT_TIMEOUT_SECONDS = 300
 DEFAULT_POLL_INTERVAL_SECONDS = 0.5
+MIN_POLL_INTERVAL_SECONDS = 0.1
 HTTP_REQUEST_TIMEOUT_SECONDS = 10
 
 class PangramText:
@@ -119,7 +120,7 @@ class PangramText:
         :type public_dashboard_link: bool
         :param timeout: Maximum seconds to wait for the async task to complete. Defaults to 300.
         :type timeout: float
-        :param poll_interval: Seconds to wait between polling attempts. Defaults to 0.5.
+        :param poll_interval: Seconds to wait between polling attempts. Values below 0.1 are clamped to 0.1. Defaults to 0.5.
         :type poll_interval: float
         :return: Pangram analysis with AI-assistance detection as a dict with the following fields:
 
@@ -156,7 +157,12 @@ class PangramText:
 
         deadline = time.monotonic() + timeout
         task_id = self._submit_prediction_task(text, deadline, public_dashboard_link)
-        return self._poll_prediction_task(task_id, deadline, timeout, poll_interval)
+        return self._poll_prediction_task(
+            task_id,
+            deadline,
+            timeout,
+            max(MIN_POLL_INTERVAL_SECONDS, poll_interval),
+        )
 
 
     def predict_short(self, text: str) -> Dict:

--- a/pangram/text_classifier.py
+++ b/pangram/text_classifier.py
@@ -194,12 +194,23 @@ class PangramText:
 
         This method iterates through the batch and calls predict() for each text.
 
+        .. deprecated::
+           This compatibility method forwards to :meth:`predict` once per
+           input text. Use :meth:`predict` directly. This method may be
+           removed on August 1, 2026.
+
         :param text_batch: A list of strings to be classified.
         :type text_batch: List[str]
         :return: A list of classification results from the API for each text in the batch.
                  Each result is a dict with the same fields as returned by predict().
         :rtype: List[Dict]
         """
+        warnings.warn(
+            "batch_predict() is deprecated and forwards to predict() once per input text. "
+            "Use predict() directly. This method may be removed on August 1, 2026.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         results = []
         for text in text_batch:
             result = self.predict(text)

--- a/pangram/text_classifier.py
+++ b/pangram/text_classifier.py
@@ -54,10 +54,10 @@ class PangramText:
             raise ValueError(f"Error returned by API: {response_json['error']}")
         return response_json
 
-    def _submit_prediction_task(self, text: str, deadline: float) -> str:
+    def _submit_prediction_task(self, text: str, deadline: float, public_dashboard_link: bool) -> str:
         response = requests.post(
             f"{API_ENDPOINT}/task",
-            json={"text": text},
+            json={"text": text, "public_dashboard_link": public_dashboard_link},
             headers=self._headers(),
             timeout=self._request_timeout(deadline),
         )
@@ -118,7 +118,7 @@ class PangramText:
 
         :param text: The text to be classified.
         :type text: str
-        :param public_dashboard_link: Kept for API compatibility. The direct async inference endpoint ignores this parameter.
+        :param public_dashboard_link: Whether to include a public dashboard link in the completed response. Defaults to False.
         :type public_dashboard_link: bool
         :param timeout: Maximum seconds to wait for the async task to complete. Defaults to 300.
         :type timeout: float
@@ -138,6 +138,7 @@ class PangramText:
                 - num_ai_segments (int): Number of text segments classified as AI.
                 - num_ai_assisted_segments (int): Number of text segments classified as AI-assisted.
                 - num_human_segments (int): Number of text segments classified as human.
+                - dashboard_link (str): A link to the dashboard page containing the full classification result, if requested.
                 - windows (list): List of text windows and their classifications. Each window contains:
                     - text (str): The window text.
                     - label (str): Descriptive classification label (e.g., "AI-Generated", "Moderately AI-Assisted").
@@ -157,7 +158,7 @@ class PangramText:
             raise ValueError("poll_interval cannot be negative")
 
         deadline = time.monotonic() + timeout
-        task_id = self._submit_prediction_task(text, deadline)
+        task_id = self._submit_prediction_task(text, deadline, public_dashboard_link)
         return self._poll_prediction_task(task_id, deadline, timeout, poll_interval)
 
 

--- a/pangram/text_classifier.py
+++ b/pangram/text_classifier.py
@@ -228,22 +228,22 @@ class PangramText:
         """
         Classify text as AI-, AI-assisted, or human-written.
 
-        Sends a request to the Pangram Text API and returns the classification result.
-        The async inference endpoint returns a dashboard link only when supported by the service.
+        Submits the text to Pangram's async inference endpoint, waits for completion,
+        and returns analysis with a public dashboard link.
 
         :param text: The text to be classified.
         :type text: str
         :return: The classification result from the API, as a dict with the following fields:
 
                 - text (string): The classified text.
-                - dashboard_link (string): A link to a dashboard page containing the classification result, if returned by the service.
-                - ai_likelihood (float): The classification of the text, on a scale from 0.0 (human) to 1.0 (AI).
-                - max_ai_likelihood (float): The maximum AI likelihood score among all windows.
-                - avg_ai_likelihood (float): The average AI likelihood score among all windows.
-                - prediction (string): A string representing the classification.
-                - short_prediction (string): A short string representing the classification ("AI", "Human", "Mixed").
-                - fraction_ai_content (float): The fraction of windows that are classified as AI.
-                - windows (list): A list of windows and their individual classifications. Each object in the list is the response from a single text prediction.
+                - dashboard_link (string): A link to a dashboard page containing the classification result.
+                - stage (string): The terminal async task stage, normally "STAGE_SUCCESS".
+                - prediction (string): Long-form prediction string describing the classification.
+                - prediction_short (string): Short-form prediction string.
+                - fraction_ai (float): Fraction of text classified as AI-written (0.0-1.0).
+                - fraction_ai_assisted (float): Fraction of text classified as AI-assisted (0.0-1.0).
+                - fraction_human (float): Fraction of text classified as human-written (0.0-1.0).
+                - windows (list): List of text windows and their classifications.
         :rtype: dict
         """
         return self.predict(text, public_dashboard_link=True)

--- a/pangram/text_classifier.py
+++ b/pangram/text_classifier.py
@@ -166,6 +166,7 @@ class PangramText:
         .. deprecated::
            This compatibility alias forwards to :meth:`predict`. Use
            :meth:`predict` directly for Pangram's current response schema.
+           This method may be removed on August 1, 2026.
 
         :param text: The text to be classified.
         :type text: str
@@ -173,7 +174,8 @@ class PangramText:
         :rtype: Dict
         """
         warnings.warn(
-            "predict_short() is deprecated and forwards to predict(). Use predict() instead.",
+            "predict_short() is deprecated and forwards to predict(). "
+            "Use predict() instead. This method may be removed on August 1, 2026.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/pangram/text_classifier.py
+++ b/pangram/text_classifier.py
@@ -53,12 +53,15 @@ class PangramText:
         return response_json
 
     def _submit_prediction_task(self, text: str, deadline: float, public_dashboard_link: bool) -> str:
-        response = requests.post(
-            f"{API_ENDPOINT}/task",
-            json={"text": text, "public_dashboard_link": public_dashboard_link},
-            headers=self._headers(),
-            timeout=self._request_timeout(deadline),
-        )
+        try:
+            response = requests.post(
+                f"{API_ENDPOINT}/task",
+                json={"text": text, "public_dashboard_link": public_dashboard_link},
+                headers=self._headers(),
+                timeout=self._request_timeout(deadline),
+            )
+        except requests.RequestException as exc:
+            raise ValueError(f"Pangram API request failed while submitting prediction task: {exc}") from exc
         response_json = self._parse_response_json(response)
         if not isinstance(response_json, dict):
             raise ValueError(f"Error returned by API: invalid task response: {response_json}")
@@ -79,11 +82,14 @@ class PangramText:
             if time.monotonic() >= deadline:
                 raise TimeoutError(f"Pangram prediction task {task_id} did not complete within {timeout:.0f}s")
 
-            response = requests.get(
-                f"{API_ENDPOINT}/task/{task_id}",
-                headers=self._headers(),
-                timeout=self._request_timeout(deadline),
-            )
+            try:
+                response = requests.get(
+                    f"{API_ENDPOINT}/task/{task_id}",
+                    headers=self._headers(),
+                    timeout=self._request_timeout(deadline),
+                )
+            except requests.RequestException as exc:
+                raise ValueError(f"Pangram API request failed while polling prediction task {task_id}: {exc}") from exc
             response_json = self._parse_response_json(response)
             if not isinstance(response_json, dict):
                 raise ValueError(f"Error returned by API: invalid task result: {response_json}")

--- a/pangram/text_classifier.py
+++ b/pangram/text_classifier.py
@@ -92,7 +92,7 @@ class PangramText:
 
             stage = response_json.get("stage")
             if stage == ASYNC_SUCCESS_STAGE:
-                return self._normalize_prediction_response(response_json)
+                return response_json
             if stage == ASYNC_FAILED_STAGE:
                 message = response_json.get("headline") or response_json.get("detail") or "task failed"
                 raise ValueError(f"Error returned by API: task {task_id} failed: {message}")
@@ -102,37 +102,6 @@ class PangramText:
             sleep_for = min(poll_interval, max(0.0, deadline - time.monotonic()))
             if sleep_for > 0:
                 time.sleep(sleep_for)
-
-    @staticmethod
-    def _normalize_prediction_response(response_json: Dict) -> Dict:
-        result = dict(response_json)
-
-        windows = response_json.get("windows")
-        if isinstance(windows, list):
-            result["windows"] = [
-                PangramText._normalize_prediction_window(window)
-                for window in windows
-            ]
-        else:
-            result["windows"] = []
-        return result
-
-    @staticmethod
-    def _normalize_prediction_window(window):
-        if not isinstance(window, dict):
-            return window
-
-        normalized = dict(window)
-        editlens = window.get("editlens")
-        label = window.get("label")
-        if isinstance(editlens, dict):
-            label = editlens.get("prediction_text") or label
-        if label is not None:
-            normalized["label"] = label
-
-        if normalized.get("ai_assistance_score") is None and window.get("ai_likelihood") is not None:
-            normalized["ai_assistance_score"] = window.get("ai_likelihood")
-        return normalized
 
     def predict(
         self,
@@ -149,7 +118,7 @@ class PangramText:
 
         :param text: The text to be classified.
         :type text: str
-        :param public_dashboard_link: Kept for API compatibility. The async inference endpoint returns dashboard links only when supported by the service.
+        :param public_dashboard_link: Kept for API compatibility. The direct async inference endpoint ignores this parameter.
         :type public_dashboard_link: bool
         :param timeout: Maximum seconds to wait for the async task to complete. Defaults to 300.
         :type timeout: float
@@ -157,7 +126,6 @@ class PangramText:
         :type poll_interval: float
         :return: Pangram analysis with AI-assistance detection as a dict with the following fields:
 
-                - task_id (str): The async inference task ID.
                 - stage (str): The terminal async task stage, normally "STAGE_SUCCESS".
                 - text (str): The input text.
                 - version (str): The API version identifier (e.g., "3.0").
@@ -170,7 +138,6 @@ class PangramText:
                 - num_ai_segments (int): Number of text segments classified as AI.
                 - num_ai_assisted_segments (int): Number of text segments classified as AI-assisted.
                 - num_human_segments (int): Number of text segments classified as human.
-                - dashboard_link (str): A link to the dashboard page containing the full classification result, if returned by the service.
                 - windows (list): List of text windows and their classifications. Each window contains:
                     - text (str): The window text.
                     - label (str): Descriptive classification label (e.g., "AI-Generated", "Moderately AI-Assisted").

--- a/pangram/text_classifier.py
+++ b/pangram/text_classifier.py
@@ -1,16 +1,12 @@
 import requests
 import os
 import time
-import warnings
 from typing import List, Dict, Optional
 
 SOURCE_VERSION = "python_sdk_0.1.11"
 
 API_ENDPOINT = 'https://text.external-api.pangram.com'
-BATCH_API_ENDPOINT = 'https://text-batch.api.pangramlabs.com'
-SLIDING_WINDOW_API_ENDPOINT = 'https://text-sliding.api.pangramlabs.com'
 PLAGIARISM_API_ENDPOINT = 'https://plagiarism.api.pangram.com'
-TEXT_EXTENDED_API_ENDPOINT = 'https://text-extended.api.pangramlabs.com'
 ASYNC_SUCCESS_STAGE = 'STAGE_SUCCESS'
 ASYNC_FAILED_STAGE = 'STAGE_FAILED'
 DEFAULT_PREDICT_TIMEOUT_SECONDS = 300
@@ -181,49 +177,6 @@ class PangramText:
         return results
 
 
-    def predict_sliding_window(self, text: str):
-        """
-        Classify a long document using a sliding window to iterate across the full document.
-
-        .. deprecated:: 0.1.8
-           This method is deprecated. Use :meth:`predict` instead.
-
-        :param text: The text to be classified.
-        :type text: str
-        :return: The classification result from the API, as a dict with the following fields:
-
-                - text (string): The classified text.
-                - ai_likelihood (float): The classification of the text, on a scale from 0.0 (human) to 1.0 (AI).
-                - max_ai_likelihood (float): The maximum AI likelihood score among all windows.
-                - avg_ai_likelihood (float): The average AI likelihood score among all windows.
-                - prediction (string): A string representing the classification.
-                - short_prediction (string): A short string representing the classification ("AI", "Human", "Mixed").
-                - fraction_ai_content (float): The fraction of windows that are classified as AI.
-                - windows (list): A list of windows and their individual classifications. Each object in the list is the response from a single text prediction.
-        :rtype: dict
-        """
-        warnings.warn(
-            "predict_sliding_window() is deprecated. Use predict() instead.",
-            DeprecationWarning,
-            stacklevel=2
-        )
-        headers = {
-            'Content-Type': 'application/json',
-            'x-api-key': self.api_key,
-        }
-        input_json = {
-            "text": text,
-            "source": SOURCE_VERSION,
-        }
-        response = requests.post(SLIDING_WINDOW_API_ENDPOINT, json=input_json, headers=headers, timeout=90)
-        if response.status_code != 200:
-            raise ValueError(f"Error returned by API: [{response.status_code}] {response.text}")
-        response_json = response.json()
-        if "error" in response_json:
-            raise ValueError(f"Error returned by API: {response_json['error']}")
-        return response_json
-
-
     def predict_with_dashboard_link(self, text: str):
         """
         Classify text as AI-, AI-assisted, or human-written.
@@ -275,59 +228,6 @@ class PangramText:
         }
 
         response = requests.post(PLAGIARISM_API_ENDPOINT, json=input_json, headers=headers, timeout=90)
-        if response.status_code != 200:
-            raise ValueError(f"Error returned by API: [{response.status_code}] {response.text}")
-        response_json = response.json()
-        if "error" in response_json:
-            raise ValueError(f"Error returned by API: {response_json['error']}")
-        return response_json
-
-
-    def predict_extended(self, text: str) -> Dict:
-        """
-        Classify text as AI- or human-written with extended analysis.
-
-        Sends a request to the Pangram Text Extended API and returns precise, windowed results using adaptive boundaries 
-
-        .. deprecated:: 0.1.11
-           This method is deprecated. Use :meth:`predict` instead.
-
-        :param text: The text to be classified.
-        :type text: str
-        :return: The extended classification result from the API, as a dict with the following fields:
-
-                - text (str): The input text.
-                - avg_ai_likelihood (float): Weighted average AI likelihood score.
-                - max_ai_likelihood (float): Maximum AI likelihood score among all windows.
-                - prediction (str): Long-form prediction string.
-                - prediction_short (str): Short-form prediction string.
-                - headline (str): Classification headline.
-                - windows (list): List of text windows and their classifications.
-                - window_likelihoods (list): AI likelihood scores for each window.
-                - window_indices (list): Indices for each window.
-                - percent_human (float): Percentage classified as human-written.
-                - percent_ai (float): Percentage classified as AI-written.
-                - percent_mixed (float): Percentage classified as mixed.
-                - metadata (dict): Additional metadata about the analysis.
-                - version (str): Analysis version identifier.
-        :rtype: Dict
-        :raises ValueError: If the API returns an error or if the response is invalid
-        """
-        warnings.warn(
-            "predict_extended() is deprecated. Use predict() instead.",
-            DeprecationWarning,
-            stacklevel=2
-        )
-        headers = {
-            'Content-Type': 'application/json',
-            'x-api-key': self.api_key,
-        }
-        input_json = {
-            "text": text,
-            "source": SOURCE_VERSION,
-        }
-
-        response = requests.post(TEXT_EXTENDED_API_ENDPOINT, json=input_json, headers=headers, timeout=90)
         if response.status_code != 200:
             raise ValueError(f"Error returned by API: [{response.status_code}] {response.text}")
         response_json = response.json()

--- a/pangram/text_classifier.py
+++ b/pangram/text_classifier.py
@@ -1,6 +1,7 @@
 import requests
 import os
 import time
+import warnings
 from typing import List, Dict, Optional
 
 SOURCE_VERSION = "python_sdk_0.1.11"
@@ -156,6 +157,27 @@ class PangramText:
         deadline = time.monotonic() + timeout
         task_id = self._submit_prediction_task(text, deadline, public_dashboard_link)
         return self._poll_prediction_task(task_id, deadline, timeout, poll_interval)
+
+
+    def predict_short(self, text: str) -> Dict:
+        """
+        Classify text using the main async prediction endpoint.
+
+        .. deprecated::
+           This compatibility alias forwards to :meth:`predict`. Use
+           :meth:`predict` directly for Pangram's current response schema.
+
+        :param text: The text to be classified.
+        :type text: str
+        :return: The same classification result returned by :meth:`predict`.
+        :rtype: Dict
+        """
+        warnings.warn(
+            "predict_short() is deprecated and forwards to predict(). Use predict() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.predict(text)
 
 
     def batch_predict(self, text_batch: List[str]) -> List[Dict]:

--- a/pangram/text_classifier.py
+++ b/pangram/text_classifier.py
@@ -11,7 +11,7 @@ ASYNC_SUCCESS_STAGE = 'STAGE_SUCCESS'
 ASYNC_FAILED_STAGE = 'STAGE_FAILED'
 DEFAULT_PREDICT_TIMEOUT_SECONDS = 300
 DEFAULT_POLL_INTERVAL_SECONDS = 0.5
-REQUEST_TIMEOUT_SECONDS = 10
+HTTP_REQUEST_TIMEOUT_SECONDS = 10
 
 class PangramText:
     def __init__(self, api_key: Optional[str] = None) -> None:
@@ -37,7 +37,7 @@ class PangramText:
 
     def _request_timeout(self, deadline: float) -> float:
         remaining = deadline - time.monotonic()
-        return max(0.1, min(REQUEST_TIMEOUT_SECONDS, remaining))
+        return max(0.1, min(HTTP_REQUEST_TIMEOUT_SECONDS, remaining))
 
     def _parse_response_json(self, response: requests.Response):
         if response.status_code != 200:

--- a/pangram/text_classifier.py
+++ b/pangram/text_classifier.py
@@ -89,7 +89,14 @@ class PangramText:
                     timeout=self._request_timeout(deadline),
                 )
             except requests.RequestException as exc:
-                raise ValueError(f"Pangram API request failed while polling prediction task {task_id}: {exc}") from exc
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(
+                        f"Pangram prediction task {task_id} did not complete within {timeout:.0f}s"
+                    ) from exc
+                sleep_for = min(poll_interval, max(0.0, deadline - time.monotonic()))
+                if sleep_for > 0:
+                    time.sleep(sleep_for)
+                continue
             response_json = self._parse_response_json(response)
             if not isinstance(response_json, dict):
                 raise ValueError(f"Error returned by API: invalid task result: {response_json}")

--- a/pangram/text_classifier.py
+++ b/pangram/text_classifier.py
@@ -6,7 +6,7 @@ from typing import List, Dict, Optional
 
 SOURCE_VERSION = "python_sdk_0.1.11"
 
-API_ENDPOINT = 'https://text-async.aws.pangram.com'
+API_ENDPOINT = 'https://text.external-api.pangram.com'
 BATCH_API_ENDPOINT = 'https://text-batch.api.pangramlabs.com'
 SLIDING_WINDOW_API_ENDPOINT = 'https://text-sliding.api.pangramlabs.com'
 PLAGIARISM_API_ENDPOINT = 'https://plagiarism.api.pangram.com'
@@ -106,15 +106,15 @@ class PangramText:
     @staticmethod
     def _normalize_prediction_response(response_json: Dict) -> Dict:
         result = dict(response_json)
-        result.pop("task_id", None)
-        result.pop("stage", None)
 
-        windows = result.get("windows")
+        windows = response_json.get("windows")
         if isinstance(windows, list):
             result["windows"] = [
                 PangramText._normalize_prediction_window(window)
                 for window in windows
             ]
+        else:
+            result["windows"] = []
         return result
 
     @staticmethod
@@ -122,30 +122,17 @@ class PangramText:
         if not isinstance(window, dict):
             return window
 
+        normalized = dict(window)
         editlens = window.get("editlens")
         label = window.get("label")
         if isinstance(editlens, dict):
             label = editlens.get("prediction_text") or label
+        if label is not None:
+            normalized["label"] = label
 
-        ai_assistance_score = window.get("ai_assistance_score")
-        if ai_assistance_score is None:
-            ai_assistance_score = window.get("ai_likelihood")
-
-        normalized = {
-            "text": window.get("text"),
-            "label": label,
-            "ai_assistance_score": ai_assistance_score,
-            "confidence": window.get("confidence"),
-            "start_index": window.get("start_index"),
-            "end_index": window.get("end_index"),
-            "word_count": window.get("word_count"),
-            "token_length": window.get("token_length"),
-        }
-        return {
-            key: value
-            for key, value in normalized.items()
-            if value is not None
-        }
+        if normalized.get("ai_assistance_score") is None and window.get("ai_likelihood") is not None:
+            normalized["ai_assistance_score"] = window.get("ai_likelihood")
+        return normalized
 
     def predict(
         self,
@@ -157,7 +144,7 @@ class PangramText:
         """
         Classify text as AI-, AI-assisted, or human-written.
 
-        Submits the text to Pangram's async AWS inference endpoint, waits for completion,
+        Submits the text to Pangram's async inference endpoint, waits for completion,
         and returns analysis with windowed results.
 
         :param text: The text to be classified.
@@ -170,6 +157,8 @@ class PangramText:
         :type poll_interval: float
         :return: Pangram analysis with AI-assistance detection as a dict with the following fields:
 
+                - task_id (str): The async inference task ID.
+                - stage (str): The terminal async task stage, normally "STAGE_SUCCESS".
                 - text (str): The input text.
                 - version (str): The API version identifier (e.g., "3.0").
                 - headline (str): Classification headline summarizing the result.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pangram-sdk"
-version = "0.1.11"
+version = "0.2.0"
 description = ""
 authors = ["Max Spero <max@pangramlabs.com>"]
 readme = "README.md"

--- a/tests/pangram_test.py
+++ b/tests/pangram_test.py
@@ -31,6 +31,24 @@ class TestPredict(unittest.TestCase):
                     "task_id": "task-1",
                     "stage": "STAGE_SUCCESS",
                     "text": text,
+                    "version": "3.1",
+                    "headline": "AI Detected",
+                    "prediction": "We believe this is mixed content",
+                    "prediction_short": "Mixed",
+                    "fraction_ai": 0.2,
+                    "fraction_ai_assisted": 0.3,
+                    "fraction_human": 0.5,
+                    "fraction_mixed": 0.3,
+                    "avg_ai_likelihood": 0.4,
+                    "fraction_breakdown": {
+                        "ai": {"high-confidence": 0.2},
+                        "ai-assisted": {"lightly": 0.1, "moderately": 0.2},
+                        "human": {"high-confidence": 0.5},
+                    },
+                    "num_ai_segments": 1,
+                    "num_ai_assisted_segments": 2,
+                    "num_human_segments": 3,
+                    "window_indices": [[0, 45]],
                     "windows": [
                         {
                             "text": "I recently had the pleasure of visiting OpenAI.",
@@ -53,10 +71,19 @@ class TestPredict(unittest.TestCase):
         self.assertEqual(mock_post.call_args.kwargs["json"], {"text": text})
         self.assertEqual(mock_post.call_args.kwargs["headers"]["x-api-key"], "test-key")
         self.assertEqual(result['text'], text)
-        self.assertNotIn("task_id", result)
-        self.assertNotIn("stage", result)
+        self.assertEqual(result["task_id"], "task-1")
+        self.assertEqual(result["stage"], "STAGE_SUCCESS")
+        self.assertEqual(result["version"], "3.1")
+        self.assertEqual(result["prediction_short"], "Mixed")
+        self.assertEqual(result["num_ai_segments"], 1)
+        self.assertEqual(result["fraction_mixed"], 0.3)
+        self.assertEqual(result["avg_ai_likelihood"], 0.4)
+        self.assertEqual(result["fraction_breakdown"]["ai-assisted"], {"lightly": 0.1, "moderately": 0.2})
+        self.assertEqual(result["window_indices"], [[0, 45]])
         self.assertEqual(result["windows"][0]["ai_assistance_score"], 0.92)
         self.assertEqual(result["windows"][0]["label"], "AI-Generated")
+        self.assertEqual(result["windows"][0]["ai_likelihood"], 0.92)
+        self.assertEqual(result["windows"][0]["editlens"], {"prediction_text": "AI-Generated"})
 
     def test_predict_raises_when_async_task_fails(self):
         pangram_client = Pangram(api_key="test-key")

--- a/tests/pangram_test.py
+++ b/tests/pangram_test.py
@@ -1,4 +1,5 @@
 import unittest
+import requests
 from pangram import Pangram, PangramText
 from pangram.text_classifier import API_ENDPOINT, MIN_POLL_INTERVAL_SECONDS
 import os
@@ -84,6 +85,27 @@ class TestPredict(unittest.TestCase):
         pangram_client = Pangram(api_key="test-key")
         with self.assertRaisesRegex(ValueError, "timeout must be greater than 0"):
             pangram_client.predict("hello", timeout=0)
+
+    def test_predict_wraps_submit_request_errors(self):
+        pangram_client = Pangram(api_key="test-key")
+        with patch(
+            "pangram.text_classifier.requests.post",
+            side_effect=requests.exceptions.Timeout("timed out"),
+        ):
+            with self.assertRaisesRegex(ValueError, "submitting prediction task: timed out"):
+                pangram_client.predict("hello")
+
+    def test_predict_wraps_poll_request_errors(self):
+        pangram_client = Pangram(api_key="test-key")
+        with patch(
+            "pangram.text_classifier.requests.post",
+            return_value=MockResponse(json_data={"task_id": "task-1"}),
+        ), patch(
+            "pangram.text_classifier.requests.get",
+            side_effect=requests.exceptions.ConnectionError("connection dropped"),
+        ):
+            with self.assertRaisesRegex(ValueError, "polling prediction task task-1: connection dropped"):
+                pangram_client.predict("hello", poll_interval=0)
 
     def test_predict_short_forwards_to_predict(self):
         text = "hello!"

--- a/tests/pangram_test.py
+++ b/tests/pangram_test.py
@@ -94,15 +94,6 @@ class TestBatchPredict(unittest.TestCase):
             results = pangram_client.batch_predict(text_batch)
         self.assertEqual(len(results), len(text_batch))
 
-class TestSlidingWindow(unittest.TestCase):
-    @unittest.skipUnless(os.getenv('PANGRAM_API_KEY'), "requires PANGRAM_API_KEY")
-    def test_sliding_window(self):
-        text = "hello!"
-        pangram_client = Pangram()
-        result = pangram_client.predict_sliding_window(text)
-        self.assertEqual(result['text'], text)
-        self.assertIn('windows', result)
-
 class TestDashboard(unittest.TestCase):
     def test_dashboard(self):
         text = "hello!"

--- a/tests/pangram_test.py
+++ b/tests/pangram_test.py
@@ -102,7 +102,8 @@ class TestBatchPredict(unittest.TestCase):
         text_batch = [text1, text2]
         pangram_client = Pangram(api_key="test-key")
         with patch.object(PangramText, "predict", side_effect=[{"text": text1}, {"text": text2}]):
-            results = pangram_client.batch_predict(text_batch)
+            with self.assertWarnsRegex(DeprecationWarning, "batch_predict"):
+                results = pangram_client.batch_predict(text_batch)
         self.assertEqual(len(results), len(text_batch))
 
 class TestDashboard(unittest.TestCase):

--- a/tests/pangram_test.py
+++ b/tests/pangram_test.py
@@ -84,6 +84,16 @@ class TestPredict(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "timeout must be greater than 0"):
             pangram_client.predict("hello", timeout=0)
 
+    def test_predict_short_forwards_to_predict(self):
+        text = "hello!"
+        pangram_client = Pangram(api_key="test-key")
+        with patch.object(PangramText, "predict", return_value={"text": text}) as mock_predict:
+            with self.assertWarnsRegex(DeprecationWarning, "predict_short"):
+                result = pangram_client.predict_short(text)
+
+        mock_predict.assert_called_once_with(text)
+        self.assertEqual(result, {"text": text})
+
 class TestBatchPredict(unittest.TestCase):
     def test_batch_predict(self):
         text1 = "I recently had the pleasure of visiting OpenAI. As an AI language model, I cannot actually visit places."

--- a/tests/pangram_test.py
+++ b/tests/pangram_test.py
@@ -59,7 +59,7 @@ class TestPredict(unittest.TestCase):
             result = pangram_client.predict(text, poll_interval=0)
 
         self.assertEqual(mock_post.call_args.args[0], f"{API_ENDPOINT}/task")
-        self.assertEqual(mock_post.call_args.kwargs["json"], {"text": text})
+        self.assertEqual(mock_post.call_args.kwargs["json"], {"text": text, "public_dashboard_link": False})
         self.assertEqual(mock_post.call_args.kwargs["headers"]["x-api-key"], "test-key")
         self.assertEqual(result, success_response)
 
@@ -107,10 +107,25 @@ class TestDashboard(unittest.TestCase):
     def test_dashboard(self):
         text = "hello!"
         pangram_client = Pangram(api_key="test-key")
-        with patch.object(PangramText, "predict", return_value={"text": text}) as mock_predict:
+        success_response = {
+            "stage": "STAGE_SUCCESS",
+            "text": text,
+            "dashboard_link": "https://www.pangram.com/history/query-1",
+            "windows": [],
+        }
+
+        with patch(
+            "pangram.text_classifier.requests.post",
+            return_value=MockResponse(json_data={"task_id": "task-1"}),
+        ) as mock_post, patch(
+            "pangram.text_classifier.requests.get",
+            return_value=MockResponse(json_data=success_response),
+        ):
             result = pangram_client.predict_with_dashboard_link(text)
-        self.assertEqual(result['text'], text)
-        mock_predict.assert_called_once_with(text, public_dashboard_link=True)
+
+        self.assertEqual(mock_post.call_args.args[0], f"{API_ENDPOINT}/task")
+        self.assertEqual(mock_post.call_args.kwargs["json"], {"text": text, "public_dashboard_link": True})
+        self.assertEqual(result, success_response)
 
 class TestPlagiarism(unittest.TestCase):
     @unittest.skipUnless(os.getenv('PANGRAM_API_KEY'), "requires PANGRAM_API_KEY")

--- a/tests/pangram_test.py
+++ b/tests/pangram_test.py
@@ -1,6 +1,6 @@
 import unittest
 from pangram import Pangram, PangramText
-from pangram.text_classifier import API_ENDPOINT
+from pangram.text_classifier import API_ENDPOINT, MIN_POLL_INTERVAL_SECONDS
 import os
 from unittest.mock import patch
 
@@ -55,12 +55,13 @@ class TestPredict(unittest.TestCase):
                 MockResponse(json_data={"task_id": "task-1", "stage": "STAGE_PREPROCESSING"}),
                 MockResponse(json_data=success_response),
             ],
-        ):
+        ), patch("pangram.text_classifier.time.sleep") as mock_sleep:
             result = pangram_client.predict(text, poll_interval=0)
 
         self.assertEqual(mock_post.call_args.args[0], f"{API_ENDPOINT}/task")
         self.assertEqual(mock_post.call_args.kwargs["json"], {"text": text, "public_dashboard_link": False})
         self.assertEqual(mock_post.call_args.kwargs["headers"]["x-api-key"], "test-key")
+        mock_sleep.assert_called_once_with(MIN_POLL_INTERVAL_SECONDS)
         self.assertEqual(result, success_response)
 
     def test_predict_raises_when_async_task_fails(self):

--- a/tests/pangram_test.py
+++ b/tests/pangram_test.py
@@ -95,17 +95,28 @@ class TestPredict(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "submitting prediction task: timed out"):
                 pangram_client.predict("hello")
 
-    def test_predict_wraps_poll_request_errors(self):
+    def test_predict_retries_poll_request_errors(self):
         pangram_client = Pangram(api_key="test-key")
+        success_response = {
+            "stage": "STAGE_SUCCESS",
+            "text": "hello",
+            "prediction_short": "Human",
+            "windows": [],
+        }
         with patch(
             "pangram.text_classifier.requests.post",
             return_value=MockResponse(json_data={"task_id": "task-1"}),
         ), patch(
             "pangram.text_classifier.requests.get",
-            side_effect=requests.exceptions.ConnectionError("connection dropped"),
-        ):
-            with self.assertRaisesRegex(ValueError, "polling prediction task task-1: connection dropped"):
-                pangram_client.predict("hello", poll_interval=0)
+            side_effect=[
+                requests.exceptions.ConnectionError("connection dropped"),
+                MockResponse(json_data=success_response),
+            ],
+        ), patch("pangram.text_classifier.time.sleep") as mock_sleep:
+            result = pangram_client.predict("hello", poll_interval=0)
+
+        mock_sleep.assert_called_once_with(MIN_POLL_INTERVAL_SECONDS)
+        self.assertEqual(result, success_response)
 
     def test_predict_short_forwards_to_predict(self):
         text = "hello!"

--- a/tests/pangram_test.py
+++ b/tests/pangram_test.py
@@ -1,25 +1,96 @@
 import unittest
 from pangram import Pangram, PangramText
+from pangram.text_classifier import API_ENDPOINT
 import os
+from unittest.mock import patch
+
+
+class MockResponse:
+    def __init__(self, status_code=200, json_data=None, text=""):
+        self.status_code = status_code
+        self._json_data = json_data
+        self.text = text
+
+    def json(self):
+        return self._json_data
 
 
 class TestPredict(unittest.TestCase):
     def test_predict(self):
-        pangram_client = Pangram()
         text = "I recently had the pleasure of visiting OpenAI. As an AI language model, I cannot actually visit places."
-        result = pangram_client.predict(text)
+        pangram_client = Pangram(api_key="test-key")
+
+        with patch(
+            "pangram.text_classifier.requests.post",
+            return_value=MockResponse(json_data={"task_id": "task-1"}),
+        ) as mock_post, patch(
+            "pangram.text_classifier.requests.get",
+            side_effect=[
+                MockResponse(json_data={"task_id": "task-1", "stage": "STAGE_PREPROCESSING"}),
+                MockResponse(json_data={
+                    "task_id": "task-1",
+                    "stage": "STAGE_SUCCESS",
+                    "text": text,
+                    "windows": [
+                        {
+                            "text": "I recently had the pleasure of visiting OpenAI.",
+                            "ai_likelihood": 0.92,
+                            "label": "AI-Generated",
+                            "editlens": {"prediction_text": "AI-Generated"},
+                            "confidence": "High",
+                            "start_index": 0,
+                            "end_index": 45,
+                            "word_count": 8,
+                            "token_length": 10,
+                        }
+                    ],
+                }),
+            ],
+        ):
+            result = pangram_client.predict(text, poll_interval=0)
+
+        self.assertEqual(mock_post.call_args.args[0], f"{API_ENDPOINT}/task")
+        self.assertEqual(mock_post.call_args.kwargs["json"], {"text": text})
+        self.assertEqual(mock_post.call_args.kwargs["headers"]["x-api-key"], "test-key")
         self.assertEqual(result['text'], text)
+        self.assertNotIn("task_id", result)
+        self.assertNotIn("stage", result)
+        self.assertEqual(result["windows"][0]["ai_assistance_score"], 0.92)
+        self.assertEqual(result["windows"][0]["label"], "AI-Generated")
+
+    def test_predict_raises_when_async_task_fails(self):
+        pangram_client = Pangram(api_key="test-key")
+        with patch(
+            "pangram.text_classifier.requests.post",
+            return_value=MockResponse(json_data={"task_id": "task-1"}),
+        ), patch(
+            "pangram.text_classifier.requests.get",
+            return_value=MockResponse(json_data={
+                "task_id": "task-1",
+                "stage": "STAGE_FAILED",
+                "headline": "processing failed",
+            }),
+        ):
+            with self.assertRaisesRegex(ValueError, "processing failed"):
+                pangram_client.predict("hello", poll_interval=0)
+
+    def test_predict_rejects_invalid_timeout(self):
+        pangram_client = Pangram(api_key="test-key")
+        with self.assertRaisesRegex(ValueError, "timeout must be greater than 0"):
+            pangram_client.predict("hello", timeout=0)
 
 class TestBatchPredict(unittest.TestCase):
     def test_batch_predict(self):
         text1 = "I recently had the pleasure of visiting OpenAI. As an AI language model, I cannot actually visit places."
         text2 = "i'm a human"
         text_batch = [text1, text2]
-        pangram_client = Pangram()
-        results = pangram_client.batch_predict(text_batch)
+        pangram_client = Pangram(api_key="test-key")
+        with patch.object(PangramText, "predict", side_effect=[{"text": text1}, {"text": text2}]):
+            results = pangram_client.batch_predict(text_batch)
         self.assertEqual(len(results), len(text_batch))
 
 class TestSlidingWindow(unittest.TestCase):
+    @unittest.skipUnless(os.getenv('PANGRAM_API_KEY'), "requires PANGRAM_API_KEY")
     def test_sliding_window(self):
         text = "hello!"
         pangram_client = Pangram()
@@ -30,12 +101,14 @@ class TestSlidingWindow(unittest.TestCase):
 class TestDashboard(unittest.TestCase):
     def test_dashboard(self):
         text = "hello!"
-        pangram_client = Pangram()
-        result = pangram_client.predict_with_dashboard_link(text)
+        pangram_client = Pangram(api_key="test-key")
+        with patch.object(PangramText, "predict", return_value={"text": text}) as mock_predict:
+            result = pangram_client.predict_with_dashboard_link(text)
         self.assertEqual(result['text'], text)
-        self.assertIn('dashboard_link', result)
+        mock_predict.assert_called_once_with(text, public_dashboard_link=True)
 
 class TestPlagiarism(unittest.TestCase):
+    @unittest.skipUnless(os.getenv('PANGRAM_API_KEY'), "requires PANGRAM_API_KEY")
     def test_plagiarism(self):
         text = "hello!"
         pangram_client = Pangram()
@@ -51,10 +124,10 @@ class TestPangramText(unittest.TestCase):
         """
         Ensure legacy syntax using PangramText
         """
-        api_key = os.getenv('PANGRAM_API_KEY')
-        pangram_client = PangramText(api_key=api_key)
+        pangram_client = PangramText(api_key="test-key")
         text = "I recently had the pleasure of visiting OpenAI. As an AI language model, I cannot actually visit places."
-        result = pangram_client.predict(text)
+        with patch.object(PangramText, "predict", return_value={"text": text}):
+            result = pangram_client.predict(text)
         self.assertEqual(result['text'], text)
 
 if __name__ == '__main__':

--- a/tests/pangram_test.py
+++ b/tests/pangram_test.py
@@ -19,6 +19,32 @@ class TestPredict(unittest.TestCase):
     def test_predict(self):
         text = "I recently had the pleasure of visiting OpenAI. As an AI language model, I cannot actually visit places."
         pangram_client = Pangram(api_key="test-key")
+        success_response = {
+            "stage": "STAGE_SUCCESS",
+            "text": text,
+            "version": "3.1",
+            "headline": "AI Detected",
+            "prediction": "We believe this is mixed content",
+            "prediction_short": "Mixed",
+            "fraction_ai": 0.2,
+            "fraction_ai_assisted": 0.3,
+            "fraction_human": 0.5,
+            "num_ai_segments": 1,
+            "num_ai_assisted_segments": 2,
+            "num_human_segments": 3,
+            "windows": [
+                {
+                    "text": "I recently had the pleasure of visiting OpenAI.",
+                    "label": "AI-Generated",
+                    "ai_assistance_score": 0.92,
+                    "confidence": "High",
+                    "start_index": 0,
+                    "end_index": 45,
+                    "word_count": 8,
+                    "token_length": 10,
+                }
+            ],
+        }
 
         with patch(
             "pangram.text_classifier.requests.post",
@@ -27,42 +53,7 @@ class TestPredict(unittest.TestCase):
             "pangram.text_classifier.requests.get",
             side_effect=[
                 MockResponse(json_data={"task_id": "task-1", "stage": "STAGE_PREPROCESSING"}),
-                MockResponse(json_data={
-                    "task_id": "task-1",
-                    "stage": "STAGE_SUCCESS",
-                    "text": text,
-                    "version": "3.1",
-                    "headline": "AI Detected",
-                    "prediction": "We believe this is mixed content",
-                    "prediction_short": "Mixed",
-                    "fraction_ai": 0.2,
-                    "fraction_ai_assisted": 0.3,
-                    "fraction_human": 0.5,
-                    "fraction_mixed": 0.3,
-                    "avg_ai_likelihood": 0.4,
-                    "fraction_breakdown": {
-                        "ai": {"high-confidence": 0.2},
-                        "ai-assisted": {"lightly": 0.1, "moderately": 0.2},
-                        "human": {"high-confidence": 0.5},
-                    },
-                    "num_ai_segments": 1,
-                    "num_ai_assisted_segments": 2,
-                    "num_human_segments": 3,
-                    "window_indices": [[0, 45]],
-                    "windows": [
-                        {
-                            "text": "I recently had the pleasure of visiting OpenAI.",
-                            "ai_likelihood": 0.92,
-                            "label": "AI-Generated",
-                            "editlens": {"prediction_text": "AI-Generated"},
-                            "confidence": "High",
-                            "start_index": 0,
-                            "end_index": 45,
-                            "word_count": 8,
-                            "token_length": 10,
-                        }
-                    ],
-                }),
+                MockResponse(json_data=success_response),
             ],
         ):
             result = pangram_client.predict(text, poll_interval=0)
@@ -70,20 +61,7 @@ class TestPredict(unittest.TestCase):
         self.assertEqual(mock_post.call_args.args[0], f"{API_ENDPOINT}/task")
         self.assertEqual(mock_post.call_args.kwargs["json"], {"text": text})
         self.assertEqual(mock_post.call_args.kwargs["headers"]["x-api-key"], "test-key")
-        self.assertEqual(result['text'], text)
-        self.assertEqual(result["task_id"], "task-1")
-        self.assertEqual(result["stage"], "STAGE_SUCCESS")
-        self.assertEqual(result["version"], "3.1")
-        self.assertEqual(result["prediction_short"], "Mixed")
-        self.assertEqual(result["num_ai_segments"], 1)
-        self.assertEqual(result["fraction_mixed"], 0.3)
-        self.assertEqual(result["avg_ai_likelihood"], 0.4)
-        self.assertEqual(result["fraction_breakdown"]["ai-assisted"], {"lightly": 0.1, "moderately": 0.2})
-        self.assertEqual(result["window_indices"], [[0, 45]])
-        self.assertEqual(result["windows"][0]["ai_assistance_score"], 0.92)
-        self.assertEqual(result["windows"][0]["label"], "AI-Generated")
-        self.assertEqual(result["windows"][0]["ai_likelihood"], 0.92)
-        self.assertEqual(result["windows"][0]["editlens"], {"prediction_text": "AI-Generated"})
+        self.assertEqual(result, success_response)
 
     def test_predict_raises_when_async_task_fails(self):
         pangram_client = Pangram(api_key="test-key")


### PR DESCRIPTION
## Summary
- bump the SDK version to `0.2.0` for the async prediction behavior change
- route Pangram SDK `predict()` through the direct async inference endpoint at `text.external-api.pangram.com`
- submit `POST /task`, poll `GET /task/{task_id}` until a terminal stage, and return the async task payload unchanged
- wrap async submit transport failures in clear SDK-facing errors
- retry transient async poll transport failures within the existing overall prediction timeout
- forward dashboard-link requests through the async `public_dashboard_link` field
- remove stale deprecated text endpoint methods and constants for sliding-window and extended prediction
- keep `predict_short()` as a deprecated compatibility alias to `predict()`, with removal no earlier than August 1, 2026
- keep `batch_predict()` as a deprecated compatibility method that calls `predict()` once per input text, with removal no earlier than August 1, 2026
- remove the internal `priority` queue knob from public REST docs and add a failed-task response example
- add a poll interval floor so callers cannot create a tight polling loop
- update SDK docs and REST docs for the checked-in async pipeline contract
- fix the repo guide single-test command to use valid unittest module syntax
- add mocked unit coverage for async submit/poll, failed tasks, submit request exceptions, retried poll request exceptions, dashboard links, batch forwarding, and compatibility deprecation warnings

## Tests
- `pytest -q` -> `9 passed, 1 skipped`
- `python -m unittest tests.pangram_test.TestPredict.test_predict` -> `OK`
- focused serving contract tests on `pangram-internal` `origin/main` -> `20 passed, 5 warnings`
- `git diff --check`

## Notes
- The branch is rebased onto current SDK main and keeps main dependency-security updates.
- The SDK no longer calls `text.api.pangram.com`, `text-batch`, `text-sliding`, or `text-extended` for text prediction.