### PR TITLE
Update Sigstore release action

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -65,7 +65,7 @@ jobs:
         name: python-package-distributions
         path: dist/
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v2.1.1
+      uses: sigstore/gh-action-sigstore-python@v3.3.0
       with:
         inputs: >-
           ./dist/*.tar.gz


### PR DESCRIPTION
## Summary
- update `sigstore/gh-action-sigstore-python` from `v2.1.1` to `v3.3.0`
- fixes release signing job failure caused by the old action using deprecated `actions/upload-artifact@v3` internally

## Tests
- parsed `.github/workflows/publish-to-pypi.yml` with PyYAML
- `git diff --check`

## Notes
- This does not republish PyPI artifacts. It only fixes the workflow for future release/signing runs.