### PR TITLE
Add Bulk API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,43 @@ for window in result['windows']:
 `predict()` submits to Pangram's async inference API and waits for the result before returning.
 Use `predict(text, public_dashboard_link=True)` or `predict_with_dashboard_link(text)` to include a `dashboard_link` in the completed result.
 
+### Submit a Bulk API job
+
+Use the Bulk API for asynchronous AI detection across many inputs.
+Submit either a list of strings with `text` or a list of objects with `items`.
+Item `id` values are optional customer IDs that are returned with item status
+and results.
+
+```
+from pangram import Pangram
+
+pangram_client = Pangram()
+
+bulk = pangram_client.submit_bulk(items=[
+    {"id": "row-001", "text": "First text to analyze"},
+    {"id": "row-002", "text": "Second text to analyze"},
+])
+
+bulk_id = bulk["bulk_id"]
+status = pangram_client.wait_for_bulk(bulk_id, poll_interval=2)
+results = pangram_client.get_bulk_results(bulk_id, limit=100)
+
+for item in results["items"]:
+    if item["result"] is not None:
+        print(item["id"], item["result"]["prediction_short"])
+
+for failed in results["failed_items"]:
+    print(failed["id"], failed["error"])
+```
+
+Bulk jobs can also be inspected without waiting:
+
+```
+status = pangram_client.get_bulk_status(bulk_id)
+items = pangram_client.get_bulk_items(bulk_id, offset=0, limit=100)
+results = pangram_client.get_bulk_results(bulk_id, offset=0, limit=100)
+```
+
 ### Building Documentation
 
 Install docs dependencies and build:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ bulk = pangram_client.submit_bulk(items=[
 
 bulk_id = bulk["bulk_id"]
 status = pangram_client.wait_for_bulk(bulk_id, poll_interval=2)
-results = pangram_client.get_bulk_results(bulk_id, limit=100)
+results = pangram_client.get_bulk_results(bulk_id)
 
 for item in results["items"]:
     if item["result"] is not None:
@@ -80,7 +80,7 @@ Bulk jobs can also be inspected without waiting:
 ```
 status = pangram_client.get_bulk_status(bulk_id)
 items = pangram_client.get_bulk_items(bulk_id, offset=0, limit=100)
-results = pangram_client.get_bulk_results(bulk_id, offset=0, limit=100)
+results_page = pangram_client.get_bulk_results_page(bulk_id, offset=0, limit=100)
 ```
 
 ### Building Documentation

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Submit either a list of strings with `text` or a list of objects with `items`.
 Item `id` values are optional customer IDs that are returned with item status
 and results.
 
+Bulk jobs are processed asynchronously. Completion time depends on the number
+and length of submitted items and current system load. Use `get_bulk_status()`
+or `wait_for_bulk()` to monitor progress.
+
 ```
 from pangram import Pangram
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ for window in result['windows']:
     confidence = window['confidence']  # "High", "Medium", "Low"
 ```
 `predict()` submits to Pangram's async inference API and waits for the result before returning.
-Use `predict(text, public_dashboard_link=True)` or `predict_with_dashboard_link(text)` to include a `dashboard_link` in the completed result.
+Use `predict(text, public_dashboard_link=True)` or `predict_with_dashboard_link(text, timeout=300, poll_interval=0.5)` to include a `dashboard_link` in the completed result.
 
 ### Submit a Bulk API job
 
@@ -81,6 +81,25 @@ Bulk jobs can also be inspected without waiting:
 status = pangram_client.get_bulk_status(bulk_id)
 items = pangram_client.get_bulk_items(bulk_id, offset=0, limit=100)
 results_page = pangram_client.get_bulk_results_page(bulk_id, offset=0, limit=100)
+```
+
+For large jobs, use `get_bulk_results_page()` in a loop instead of `get_bulk_results()`
+to process one page at a time without holding the full result set in memory:
+
+```
+offset = 0
+limit = 1000
+
+while True:
+    page = pangram_client.get_bulk_results_page(bulk_id, offset=offset, limit=limit)
+    for item in page["items"]:
+        process(item)
+    for failed in page["failed_items"]:
+        handle_failure(failed)
+
+    offset += limit
+    if offset >= page["total_items"]:
+        break
 ```
 
 ### Building Documentation

--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -146,6 +146,160 @@ Poll the task endpoint until the stage is ``STAGE_SUCCESS`` or ``STAGE_FAILED``.
       "windows": []
     }
 
+Bulk API
+========
+
+The Bulk API accepts many texts, queues them as asynchronous AI detection work,
+and returns a bulk job ID. Poll the bulk status endpoint until the status is
+``succeeded``, ``failed``, or ``partial``.
+
+.. http:post:: https://text.external-api.pangram.com/bulk
+
+  :<json array text: A list of input texts. Provide either ``text`` or ``items``.
+  :<json array items: A list of objects with ``text`` and optional ``id`` fields. Provide either ``items`` or ``text``.
+  :>json string bulk_id: The ID of the bulk job.
+  :>json string status: Initial status, usually ``queued`` or ``failed`` if every item failed immediate validation.
+  :>json int total_items: Total number of submitted items.
+  :>json array accepted_items: Items accepted for processing. Each item includes ``index``, optional ``id``, and ``task_id``.
+  :>json array failed_items: Items that failed immediate validation. Each item includes ``index``, optional ``id``, ``stage``, and ``error``.
+
+  **Request Headers**
+
+  .. code-block:: json
+
+    {
+      "Content-Type": "application/json",
+      "x-api-key": "<api-key>"
+    }
+
+  **Request Body**
+
+  .. code-block:: json
+
+    {
+      "items": [
+        {"id": "row-001", "text": "First text to analyze"},
+        {"id": "row-002", "text": "Second text to analyze"}
+      ]
+    }
+
+  **Example Response**
+
+  .. code-block:: json
+
+    {
+      "bulk_id": "blk_123",
+      "status": "queued",
+      "total_items": 2,
+      "accepted_items": [
+        {"index": 0, "id": "row-001", "task_id": "123e4567-e89b-12d3-a456-426614174000"},
+        {"index": 1, "id": "row-002", "task_id": "223e4567-e89b-12d3-a456-426614174000"}
+      ],
+      "failed_items": []
+    }
+
+.. http:get:: https://text.external-api.pangram.com/bulk/(string:bulk_id)
+
+  :>json string bulk_id: The ID of the bulk job.
+  :>json string status: One of ``queued``, ``running``, ``succeeded``, ``failed``, or ``partial``.
+  :>json int total_items: Total number of submitted items.
+  :>json int accepted: Number of items accepted for processing.
+  :>json int succeeded: Number of items that completed successfully.
+  :>json int failed: Number of items that failed.
+  :>json string created_at: Job creation timestamp.
+  :>json string completed_at: Job completion timestamp, or null while non-terminal.
+
+  **Example Response**
+
+  .. code-block:: json
+
+    {
+      "bulk_id": "blk_123",
+      "status": "partial",
+      "total_items": 3,
+      "accepted": 2,
+      "succeeded": 2,
+      "failed": 1,
+      "created_at": "1760000000.0",
+      "completed_at": "1760000030.0"
+    }
+
+.. http:get:: https://text.external-api.pangram.com/bulk/(string:bulk_id)/items
+
+  :query int offset: Zero-based item offset. Defaults to 0.
+  :query int limit: Maximum number of items to return. Defaults to 100 and can be at most 1000.
+  :>json string bulk_id: The ID of the bulk job.
+  :>json int offset: The returned page offset.
+  :>json int limit: The returned page limit.
+  :>json int total_items: Total number of submitted items.
+  :>json array items: Item metadata. Each item includes ``index``, optional ``id``, ``task_id``, ``stage``, and optional ``error``.
+
+  **Example Response**
+
+  .. code-block:: json
+
+    {
+      "bulk_id": "blk_123",
+      "offset": 0,
+      "limit": 100,
+      "total_items": 2,
+      "items": [
+        {
+          "index": 0,
+          "id": "row-001",
+          "task_id": "123e4567-e89b-12d3-a456-426614174000",
+          "stage": "STAGE_SUCCESS",
+          "error": null
+        }
+      ]
+    }
+
+.. http:get:: https://text.external-api.pangram.com/bulk/(string:bulk_id)/results
+
+  :query int offset: Zero-based item offset. Defaults to 0.
+  :query int limit: Maximum number of items to return. Defaults to 100 and can be at most 1000.
+  :>json string bulk_id: The ID of the bulk job.
+  :>json int offset: The returned page offset.
+  :>json int limit: The returned page limit.
+  :>json int total_items: Total number of submitted items.
+  :>json array items: Result items. Successful completed items include ``result`` with the same shape returned by the task endpoint. In-progress items have ``result`` set to null.
+  :>json array failed_items: Failed item metadata for the requested page.
+
+  **Example Response**
+
+  .. code-block:: json
+
+    {
+      "bulk_id": "blk_123",
+      "offset": 0,
+      "limit": 100,
+      "total_items": 2,
+      "items": [
+        {
+          "index": 0,
+          "id": "row-001",
+          "task_id": "123e4567-e89b-12d3-a456-426614174000",
+          "stage": "STAGE_SUCCESS",
+          "error": null,
+          "result": {
+            "text": "First text to analyze",
+            "version": "3.3",
+            "prediction": "We believe this is human-written",
+            "prediction_short": "Human",
+            "fraction_ai": 0.0,
+            "fraction_ai_assisted": 0.0,
+            "fraction_human": 1.0,
+            "headline": "Human Written",
+            "num_ai_segments": 0,
+            "num_ai_assisted_segments": 0,
+            "num_human_segments": 1,
+            "windows": []
+          }
+        }
+      ],
+      "failed_items": []
+    }
+
 Plagiarism Detection API
 ========================
 

--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -153,6 +153,9 @@ The Bulk API accepts many texts, queues them as asynchronous AI detection work,
 and returns a bulk job ID. Poll the bulk status endpoint until the status is
 ``succeeded``, ``failed``, or ``partial``.
 
+Completion time depends on the number and length of submitted items and current
+system load. Use the bulk status endpoint to monitor progress.
+
 Bulk metadata and results are retained for 48 hours after the job reaches a
 terminal status. ``created_at`` and ``completed_at`` are returned as Unix epoch
 seconds encoded as strings, such as ``"1760000000.0"``.

--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -153,6 +153,15 @@ The Bulk API accepts many texts, queues them as asynchronous AI detection work,
 and returns a bulk job ID. Poll the bulk status endpoint until the status is
 ``succeeded``, ``failed``, or ``partial``.
 
+Bulk metadata and results are retained for 48 hours after the job reaches a
+terminal status. ``created_at`` and ``completed_at`` are returned as Unix epoch
+seconds encoded as strings, such as ``"1760000000.0"``.
+
+The launch bulk limit is 1,000 billable units per request. A billable unit is
+one started 1,000-word block per valid item, with a minimum of one unit per
+item. There is no separate item-count limit, but normal request-body limits
+still apply.
+
 .. http:post:: https://text.external-api.pangram.com/bulk
 
   :<json array text: A list of input texts. Provide either ``text`` or ``items``.
@@ -206,8 +215,8 @@ and returns a bulk job ID. Poll the bulk status endpoint until the status is
   :>json int accepted: Number of items accepted for processing.
   :>json int succeeded: Number of items that completed successfully.
   :>json int failed: Number of items that failed.
-  :>json string created_at: Job creation timestamp.
-  :>json string completed_at: Job completion timestamp, or null while non-terminal.
+  :>json string created_at: Job creation timestamp as Unix epoch seconds encoded as a string.
+  :>json string completed_at: Job completion timestamp as Unix epoch seconds encoded as a string, or null while non-terminal.
 
   **Example Response**
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -62,6 +62,10 @@ Use the Bulk API for asynchronous AI detection across many inputs. Submit either
 a ``text`` list or an ``items`` list. ``items`` can include customer-defined
 ``id`` values that are returned with item status and results.
 
+Bulk jobs are processed asynchronously. Completion time depends on the number
+and length of submitted items and current system load. Use
+``get_bulk_status()`` or ``wait_for_bulk()`` to monitor progress.
+
 .. code:: python
 
     from pangram import Pangram

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -56,6 +56,42 @@ The SDK submits to Pangram's async inference API and waits for the completed res
         ai_assistance_score = window['ai_assistance_score']
         confidence = window['confidence']
 
+Submit a Bulk API job
+~~~~~~~~~~~~~~~~~~~~~
+Use the Bulk API for asynchronous AI detection across many inputs. Submit either
+a ``text`` list or an ``items`` list. ``items`` can include customer-defined
+``id`` values that are returned with item status and results.
+
+.. code:: python
+
+    from pangram import Pangram
+
+    pangram_client = Pangram()
+
+    bulk = pangram_client.submit_bulk(items=[
+        {"id": "row-001", "text": "First text to analyze"},
+        {"id": "row-002", "text": "Second text to analyze"},
+    ])
+
+    bulk_id = bulk["bulk_id"]
+    status = pangram_client.wait_for_bulk(bulk_id, poll_interval=2)
+    results = pangram_client.get_bulk_results(bulk_id, limit=100)
+
+    for item in results["items"]:
+        if item["result"] is not None:
+            print(item["id"], item["result"]["prediction_short"])
+
+    for failed in results["failed_items"]:
+        print(failed["id"], failed["error"])
+
+You can also inspect jobs without waiting:
+
+.. code:: python
+
+    status = pangram_client.get_bulk_status(bulk_id)
+    items = pangram_client.get_bulk_items(bulk_id, offset=0, limit=100)
+    results = pangram_client.get_bulk_results(bulk_id, offset=0, limit=100)
+
 Check for Plagiarism
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -75,7 +75,7 @@ a ``text`` list or an ``items`` list. ``items`` can include customer-defined
 
     bulk_id = bulk["bulk_id"]
     status = pangram_client.wait_for_bulk(bulk_id, poll_interval=2)
-    results = pangram_client.get_bulk_results(bulk_id, limit=100)
+    results = pangram_client.get_bulk_results(bulk_id)
 
     for item in results["items"]:
         if item["result"] is not None:
@@ -90,7 +90,7 @@ You can also inspect jobs without waiting:
 
     status = pangram_client.get_bulk_status(bulk_id)
     items = pangram_client.get_bulk_items(bulk_id, offset=0, limit=100)
-    results = pangram_client.get_bulk_results(bulk_id, offset=0, limit=100)
+    results_page = pangram_client.get_bulk_results_page(bulk_id, offset=0, limit=100)
 
 Check for Plagiarism
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -92,6 +92,26 @@ You can also inspect jobs without waiting:
     items = pangram_client.get_bulk_items(bulk_id, offset=0, limit=100)
     results_page = pangram_client.get_bulk_results_page(bulk_id, offset=0, limit=100)
 
+For large jobs, use ``get_bulk_results_page()`` in a loop instead of
+``get_bulk_results()`` to process one page at a time without holding the full
+result set in memory:
+
+.. code:: python
+
+    offset = 0
+    limit = 1000
+
+    while True:
+        page = pangram_client.get_bulk_results_page(bulk_id, offset=offset, limit=limit)
+        for item in page["items"]:
+            process(item)
+        for failed in page["failed_items"]:
+            handle_failure(failed)
+
+        offset += limit
+        if offset >= page["total_items"]:
+            break
+
 Check for Plagiarism
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/pangram/__init__.py
+++ b/pangram/__init__.py
@@ -1,5 +1,5 @@
 """Defile all variables to be accessible from `import pangram`."""
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 __author__ = "Max Spero"
 __email__ = "max@pangram.com"
 __license__ = "MIT"

--- a/pangram/text_classifier.py
+++ b/pangram/text_classifier.py
@@ -481,7 +481,12 @@ class PangramText:
         return results
 
 
-    def predict_with_dashboard_link(self, text: str):
+    def predict_with_dashboard_link(
+        self,
+        text: str,
+        timeout: float = DEFAULT_PREDICT_TIMEOUT_SECONDS,
+        poll_interval: float = DEFAULT_POLL_INTERVAL_SECONDS,
+    ) -> Dict:
         """
         Classify text as AI-, AI-assisted, or human-written.
 
@@ -490,6 +495,10 @@ class PangramText:
 
         :param text: The text to be classified.
         :type text: str
+        :param timeout: Maximum seconds to wait for the async task to complete. Defaults to 300.
+        :type timeout: float
+        :param poll_interval: Seconds to wait between polling attempts. Values below 0.1 are clamped to 0.1. Defaults to 0.5.
+        :type poll_interval: float
         :return: The classification result from the API, as a dict with the following fields:
 
                 - text (string): The classified text.
@@ -502,8 +511,15 @@ class PangramText:
                 - fraction_human (float): Fraction of text classified as human-written (0.0-1.0).
                 - windows (list): List of text windows and their classifications.
         :rtype: dict
+        :raises ValueError: If the API returns an error or if the response is invalid
+        :raises TimeoutError: If the async task does not complete before timeout
         """
-        return self.predict(text, public_dashboard_link=True)
+        return self.predict(
+            text,
+            public_dashboard_link=True,
+            timeout=timeout,
+            poll_interval=poll_interval,
+        )
 
     def check_plagiarism(self, text: str) -> Dict:
         """

--- a/pangram/text_classifier.py
+++ b/pangram/text_classifier.py
@@ -16,6 +16,7 @@ DEFAULT_BULK_TIMEOUT_SECONDS = 3600
 DEFAULT_POLL_INTERVAL_SECONDS = 0.5
 MIN_POLL_INTERVAL_SECONDS = 0.1
 HTTP_REQUEST_TIMEOUT_SECONDS = 10
+MAX_BULK_PAGE_LIMIT = 1000
 
 class PangramText:
     def __init__(self, api_key: Optional[str] = None) -> None:
@@ -150,9 +151,9 @@ class PangramText:
             raise ValueError(f"Error returned by API: invalid bulk items response: {response_json}")
         return response_json
 
-    def get_bulk_results(self, bulk_id: str, offset: int = 0, limit: int = 100) -> Dict:
+    def get_bulk_results_page(self, bulk_id: str, offset: int = 0, limit: int = 100) -> Dict:
         """
-        Fetch paginated results for a Bulk API job.
+        Fetch one page of results for a Bulk API job.
 
         Completed successful items include a ``result`` field with the same
         response shape returned by :meth:`predict`. Items that are still running
@@ -182,6 +183,60 @@ class PangramText:
         if not isinstance(response_json, dict):
             raise ValueError(f"Error returned by API: invalid bulk results response: {response_json}")
         return response_json
+
+    def get_bulk_results(self, bulk_id: str, page_size: int = MAX_BULK_PAGE_LIMIT) -> Dict:
+        """
+        Fetch all available results for a Bulk API job.
+
+        This helper follows the paginated ``/bulk/{bulk_id}/results`` endpoint
+        until every submitted item index has been covered. Failed items are
+        returned separately in ``failed_items``. If the job is still running,
+        unfinished accepted items are included in ``items`` with ``result`` set
+        to ``None``.
+
+        :param bulk_id: The bulk job ID returned by :meth:`submit_bulk`.
+        :type bulk_id: str
+        :param page_size: Number of submitted item slots to request per API call.
+                          The API allows up to 1000.
+        :type page_size: int
+        :return: Aggregated bulk result response containing ``bulk_id``,
+                 ``total_items``, ``items``, and ``failed_items``.
+        :rtype: Dict
+        :raises ValueError: If page_size is invalid, or if the API returns an
+                            error or invalid response.
+        """
+        if page_size < 1 or page_size > MAX_BULK_PAGE_LIMIT:
+            raise ValueError(f"page_size must be between 1 and {MAX_BULK_PAGE_LIMIT}")
+
+        offset = 0
+        total_items = None
+        items = []
+        failed_items = []
+        response_bulk_id = bulk_id
+
+        while total_items is None or offset < total_items:
+            page = self.get_bulk_results_page(bulk_id, offset=offset, limit=page_size)
+            response_bulk_id = page.get("bulk_id", response_bulk_id)
+            page_total = page.get("total_items")
+            if not isinstance(page_total, int):
+                raise ValueError(f"Error returned by API: invalid bulk results total_items: {page}")
+            total_items = page_total
+
+            page_items = page.get("items")
+            page_failed_items = page.get("failed_items")
+            if not isinstance(page_items, list) or not isinstance(page_failed_items, list):
+                raise ValueError(f"Error returned by API: invalid bulk results page: {page}")
+
+            items.extend(page_items)
+            failed_items.extend(page_failed_items)
+            offset += page_size
+
+        return {
+            "bulk_id": response_bulk_id,
+            "total_items": total_items or 0,
+            "items": items,
+            "failed_items": failed_items,
+        }
 
     def wait_for_bulk(
         self,

--- a/pangram/text_classifier.py
+++ b/pangram/text_classifier.py
@@ -96,6 +96,17 @@ class PangramText:
             raise ValueError(f"Error returned by API: invalid bulk response: {response_json}")
         return response_json
 
+    def _fetch_bulk_status(self, bulk_id: str, request_timeout: float) -> Dict:
+        response = requests.get(
+            f"{API_ENDPOINT}/bulk/{bulk_id}",
+            headers=self._headers(),
+            timeout=request_timeout,
+        )
+        response_json = self._parse_response_json(response)
+        if not isinstance(response_json, dict):
+            raise ValueError(f"Error returned by API: invalid bulk status response: {response_json}")
+        return response_json
+
     def get_bulk_status(self, bulk_id: str) -> Dict:
         """
         Fetch the current status for a Bulk API job.
@@ -107,17 +118,9 @@ class PangramText:
         :raises ValueError: If the API returns an error or an invalid response.
         """
         try:
-            response = requests.get(
-                f"{API_ENDPOINT}/bulk/{bulk_id}",
-                headers=self._headers(),
-                timeout=HTTP_REQUEST_TIMEOUT_SECONDS,
-            )
+            return self._fetch_bulk_status(bulk_id, HTTP_REQUEST_TIMEOUT_SECONDS)
         except requests.RequestException as exc:
             raise ValueError(f"Pangram API request failed while fetching bulk status: {exc}") from exc
-        response_json = self._parse_response_json(response)
-        if not isinstance(response_json, dict):
-            raise ValueError(f"Error returned by API: invalid bulk status response: {response_json}")
-        return response_json
 
     def get_bulk_items(self, bulk_id: str, offset: int = 0, limit: int = 100) -> Dict:
         """
@@ -219,7 +222,21 @@ class PangramText:
                     f"Pangram bulk job {bulk_id} did not complete within {timeout:.0f}s; last status={last_status}"
                 )
 
-            status_response = self.get_bulk_status(bulk_id)
+            try:
+                status_response = self._fetch_bulk_status(
+                    bulk_id,
+                    self._request_timeout(deadline),
+                )
+            except requests.RequestException as exc:
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(
+                        f"Pangram bulk job {bulk_id} did not complete within {timeout:.0f}s; last status={last_status}"
+                    ) from exc
+                sleep_for = min(effective_poll_interval, max(0.0, deadline - time.monotonic()))
+                if sleep_for > 0:
+                    time.sleep(sleep_for)
+                continue
+
             last_status = status_response.get("status")
             if last_status in BULK_TERMINAL_STATUSES:
                 return status_response

--- a/pangram/text_classifier.py
+++ b/pangram/text_classifier.py
@@ -2,15 +2,17 @@ import requests
 import os
 import time
 import warnings
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Tuple
 
-SOURCE_VERSION = "python_sdk_0.2.0"
+SOURCE_VERSION = "python_sdk_0.3.0"
 
 API_ENDPOINT = 'https://text.external-api.pangram.com'
 PLAGIARISM_API_ENDPOINT = 'https://plagiarism.api.pangram.com'
 ASYNC_SUCCESS_STAGE = 'STAGE_SUCCESS'
 ASYNC_FAILED_STAGE = 'STAGE_FAILED'
+BULK_TERMINAL_STATUSES = {'succeeded', 'failed', 'partial'}
 DEFAULT_PREDICT_TIMEOUT_SECONDS = 300
+DEFAULT_BULK_TIMEOUT_SECONDS = 3600
 DEFAULT_POLL_INTERVAL_SECONDS = 0.5
 MIN_POLL_INTERVAL_SECONDS = 0.1
 HTTP_REQUEST_TIMEOUT_SECONDS = 10
@@ -41,8 +43,8 @@ class PangramText:
         remaining = deadline - time.monotonic()
         return max(0.1, min(HTTP_REQUEST_TIMEOUT_SECONDS, remaining))
 
-    def _parse_response_json(self, response: requests.Response):
-        if response.status_code != 200:
+    def _parse_response_json(self, response: requests.Response, expected_status_codes: Tuple[int, ...] = (200,)):
+        if response.status_code not in expected_status_codes:
             raise ValueError(f"Error returned by API: [{response.status_code}] {response.text}")
         try:
             response_json = response.json()
@@ -51,6 +53,180 @@ class PangramText:
         if isinstance(response_json, dict) and "error" in response_json:
             raise ValueError(f"Error returned by API: {response_json['error']}")
         return response_json
+
+    def submit_bulk(
+        self,
+        text: Optional[List[str]] = None,
+        items: Optional[List[Dict[str, str]]] = None,
+    ) -> Dict:
+        """
+        Submit a Bulk API job for asynchronous AI detection.
+
+        Provide either ``text`` as a list of input strings or ``items`` as a
+        list of dictionaries with ``text`` and an optional customer-defined
+        ``id``. The response includes a ``bulk_id`` for polling and immediate
+        per-item validation failures, if any.
+
+        :param text: A list of input texts to analyze.
+        :type text: List[str], optional
+        :param items: A list of item dictionaries. Each item must include
+                      ``text`` and may include ``id``.
+        :type items: List[Dict[str, str]], optional
+        :return: Bulk submission response containing ``bulk_id``, ``status``,
+                 ``total_items``, ``accepted_items``, and ``failed_items``.
+        :rtype: Dict
+        :raises ValueError: If both or neither payload shapes are provided, or
+                            if the API returns an error.
+        """
+        if (text is None and items is None) or (text is not None and items is not None):
+            raise ValueError("Provide exactly one of text or items")
+
+        payload = {"items": items} if items is not None else {"text": text}
+        try:
+            response = requests.post(
+                f"{API_ENDPOINT}/bulk",
+                json=payload,
+                headers=self._headers(),
+                timeout=HTTP_REQUEST_TIMEOUT_SECONDS,
+            )
+        except requests.RequestException as exc:
+            raise ValueError(f"Pangram API request failed while submitting bulk job: {exc}") from exc
+        response_json = self._parse_response_json(response, expected_status_codes=(202,))
+        if not isinstance(response_json, dict):
+            raise ValueError(f"Error returned by API: invalid bulk response: {response_json}")
+        return response_json
+
+    def get_bulk_status(self, bulk_id: str) -> Dict:
+        """
+        Fetch the current status for a Bulk API job.
+
+        :param bulk_id: The bulk job ID returned by :meth:`submit_bulk`.
+        :type bulk_id: str
+        :return: Bulk status response containing counters and timestamps.
+        :rtype: Dict
+        :raises ValueError: If the API returns an error or an invalid response.
+        """
+        try:
+            response = requests.get(
+                f"{API_ENDPOINT}/bulk/{bulk_id}",
+                headers=self._headers(),
+                timeout=HTTP_REQUEST_TIMEOUT_SECONDS,
+            )
+        except requests.RequestException as exc:
+            raise ValueError(f"Pangram API request failed while fetching bulk status: {exc}") from exc
+        response_json = self._parse_response_json(response)
+        if not isinstance(response_json, dict):
+            raise ValueError(f"Error returned by API: invalid bulk status response: {response_json}")
+        return response_json
+
+    def get_bulk_items(self, bulk_id: str, offset: int = 0, limit: int = 100) -> Dict:
+        """
+        Fetch paginated item metadata for a Bulk API job.
+
+        :param bulk_id: The bulk job ID returned by :meth:`submit_bulk`.
+        :type bulk_id: str
+        :param offset: Zero-based item offset. Defaults to 0.
+        :type offset: int
+        :param limit: Maximum number of items to return. The API allows up to 1000.
+        :type limit: int
+        :return: Paginated bulk item metadata.
+        :rtype: Dict
+        :raises ValueError: If the API returns an error or an invalid response.
+        """
+        try:
+            response = requests.get(
+                f"{API_ENDPOINT}/bulk/{bulk_id}/items",
+                params={"offset": offset, "limit": limit},
+                headers=self._headers(),
+                timeout=HTTP_REQUEST_TIMEOUT_SECONDS,
+            )
+        except requests.RequestException as exc:
+            raise ValueError(f"Pangram API request failed while fetching bulk items: {exc}") from exc
+        response_json = self._parse_response_json(response)
+        if not isinstance(response_json, dict):
+            raise ValueError(f"Error returned by API: invalid bulk items response: {response_json}")
+        return response_json
+
+    def get_bulk_results(self, bulk_id: str, offset: int = 0, limit: int = 100) -> Dict:
+        """
+        Fetch paginated results for a Bulk API job.
+
+        Completed successful items include a ``result`` field with the same
+        response shape returned by :meth:`predict`. Items that are still running
+        have ``result`` set to ``None``. Failed items are returned separately in
+        ``failed_items``.
+
+        :param bulk_id: The bulk job ID returned by :meth:`submit_bulk`.
+        :type bulk_id: str
+        :param offset: Zero-based item offset. Defaults to 0.
+        :type offset: int
+        :param limit: Maximum number of items to return. The API allows up to 1000.
+        :type limit: int
+        :return: Paginated bulk result response.
+        :rtype: Dict
+        :raises ValueError: If the API returns an error or an invalid response.
+        """
+        try:
+            response = requests.get(
+                f"{API_ENDPOINT}/bulk/{bulk_id}/results",
+                params={"offset": offset, "limit": limit},
+                headers=self._headers(),
+                timeout=HTTP_REQUEST_TIMEOUT_SECONDS,
+            )
+        except requests.RequestException as exc:
+            raise ValueError(f"Pangram API request failed while fetching bulk results: {exc}") from exc
+        response_json = self._parse_response_json(response)
+        if not isinstance(response_json, dict):
+            raise ValueError(f"Error returned by API: invalid bulk results response: {response_json}")
+        return response_json
+
+    def wait_for_bulk(
+        self,
+        bulk_id: str,
+        timeout: float = DEFAULT_BULK_TIMEOUT_SECONDS,
+        poll_interval: float = DEFAULT_POLL_INTERVAL_SECONDS,
+    ) -> Dict:
+        """
+        Poll a Bulk API job until it reaches a terminal status.
+
+        Terminal statuses are ``succeeded``, ``failed``, and ``partial``.
+
+        :param bulk_id: The bulk job ID returned by :meth:`submit_bulk`.
+        :type bulk_id: str
+        :param timeout: Maximum seconds to wait for terminal completion.
+        :type timeout: float
+        :param poll_interval: Seconds to wait between polling attempts. Values
+                              below 0.1 are clamped to 0.1.
+        :type poll_interval: float
+        :return: Terminal bulk status response.
+        :rtype: Dict
+        :raises ValueError: If timeout or poll interval values are invalid, or
+                            if the API returns an error.
+        :raises TimeoutError: If the bulk job does not complete before timeout.
+        """
+        if timeout <= 0:
+            raise ValueError("timeout must be greater than 0")
+        if poll_interval < 0:
+            raise ValueError("poll_interval cannot be negative")
+
+        deadline = time.monotonic() + timeout
+        effective_poll_interval = max(MIN_POLL_INTERVAL_SECONDS, poll_interval)
+        last_status = None
+
+        while True:
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"Pangram bulk job {bulk_id} did not complete within {timeout:.0f}s; last status={last_status}"
+                )
+
+            status_response = self.get_bulk_status(bulk_id)
+            last_status = status_response.get("status")
+            if last_status in BULK_TERMINAL_STATUSES:
+                return status_response
+
+            sleep_for = min(effective_poll_interval, max(0.0, deadline - time.monotonic()))
+            if sleep_for > 0:
+                time.sleep(sleep_for)
 
     def _submit_prediction_task(self, text: str, deadline: float, public_dashboard_link: bool) -> str:
         try:
@@ -209,8 +385,9 @@ class PangramText:
 
         .. deprecated::
            This compatibility method forwards to :meth:`predict` once per
-           input text. Use :meth:`predict` directly. This method may be
-           removed on August 1, 2026.
+           input text. Use :meth:`submit_bulk` for asynchronous bulk jobs or
+           :meth:`predict` for one-off calls. This method may be removed on
+           August 1, 2026.
 
         :param text_batch: A list of strings to be classified.
         :type text_batch: List[str]
@@ -220,7 +397,8 @@ class PangramText:
         """
         warnings.warn(
             "batch_predict() is deprecated and forwards to predict() once per input text. "
-            "Use predict() directly. This method may be removed on August 1, 2026.",
+            "Use submit_bulk() for asynchronous bulk jobs or predict() for one-off calls. "
+            "This method may be removed on August 1, 2026.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/pangram/text_classifier.py
+++ b/pangram/text_classifier.py
@@ -248,6 +248,8 @@ class PangramText:
         Poll a Bulk API job until it reaches a terminal status.
 
         Terminal statuses are ``succeeded``, ``failed``, and ``partial``.
+        Completion time depends on the number and length of submitted items and
+        current system load.
 
         :param bulk_id: The bulk job ID returned by :meth:`submit_bulk`.
         :type bulk_id: str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pangram-sdk"
-version = "0.2.0"
+version = "0.3.0"
 description = ""
 authors = ["Max Spero <max@pangramlabs.com>"]
 readme = "README.md"

--- a/tests/pangram_test.py
+++ b/tests/pangram_test.py
@@ -139,6 +139,159 @@ class TestBatchPredict(unittest.TestCase):
                 results = pangram_client.batch_predict(text_batch)
         self.assertEqual(len(results), len(text_batch))
 
+class TestBulkAPI(unittest.TestCase):
+    def test_submit_bulk_with_text_list(self):
+        pangram_client = Pangram(api_key="test-key")
+        bulk_response = {
+            "bulk_id": "blk_123",
+            "status": "queued",
+            "total_items": 2,
+            "accepted_items": [
+                {"index": 0, "id": None, "task_id": "task-1"},
+                {"index": 1, "id": None, "task_id": "task-2"},
+            ],
+            "failed_items": [],
+        }
+
+        with patch(
+            "pangram.text_classifier.requests.post",
+            return_value=MockResponse(status_code=202, json_data=bulk_response),
+        ) as mock_post:
+            result = pangram_client.submit_bulk(text=["hello", "world"])
+
+        self.assertEqual(mock_post.call_args.args[0], f"{API_ENDPOINT}/bulk")
+        self.assertEqual(mock_post.call_args.kwargs["json"], {"text": ["hello", "world"]})
+        self.assertEqual(mock_post.call_args.kwargs["headers"]["x-api-key"], "test-key")
+        self.assertEqual(result, bulk_response)
+
+    def test_submit_bulk_with_items(self):
+        pangram_client = Pangram(api_key="test-key")
+        bulk_response = {
+            "bulk_id": "blk_123",
+            "status": "queued",
+            "total_items": 2,
+            "accepted_items": [
+                {"index": 0, "id": "row-1", "task_id": "task-1"},
+            ],
+            "failed_items": [
+                {"index": 1, "id": "row-2", "task_id": None, "stage": "STAGE_FAILED", "error": "invalid text"},
+            ],
+        }
+
+        with patch(
+            "pangram.text_classifier.requests.post",
+            return_value=MockResponse(status_code=202, json_data=bulk_response),
+        ) as mock_post:
+            result = pangram_client.submit_bulk(items=[
+                {"id": "row-1", "text": "hello"},
+                {"id": "row-2", "text": ""},
+            ])
+
+        self.assertEqual(mock_post.call_args.kwargs["json"], {
+            "items": [
+                {"id": "row-1", "text": "hello"},
+                {"id": "row-2", "text": ""},
+            ]
+        })
+        self.assertEqual(result, bulk_response)
+
+    def test_submit_bulk_requires_exactly_one_payload_shape(self):
+        pangram_client = Pangram(api_key="test-key")
+        with self.assertRaisesRegex(ValueError, "exactly one"):
+            pangram_client.submit_bulk()
+        with self.assertRaisesRegex(ValueError, "exactly one"):
+            pangram_client.submit_bulk(text=["hello"], items=[{"text": "hello"}])
+
+    def test_submit_bulk_wraps_request_errors(self):
+        pangram_client = Pangram(api_key="test-key")
+        with patch(
+            "pangram.text_classifier.requests.post",
+            side_effect=requests.exceptions.Timeout("timed out"),
+        ):
+            with self.assertRaisesRegex(ValueError, "submitting bulk job: timed out"):
+                pangram_client.submit_bulk(text=["hello"])
+
+    def test_get_bulk_status(self):
+        pangram_client = Pangram(api_key="test-key")
+        status_response = {
+            "bulk_id": "blk_123",
+            "status": "running",
+            "total_items": 2,
+            "accepted": 2,
+            "succeeded": 1,
+            "failed": 0,
+            "created_at": "1760000000.0",
+            "completed_at": None,
+        }
+
+        with patch(
+            "pangram.text_classifier.requests.get",
+            return_value=MockResponse(json_data=status_response),
+        ) as mock_get:
+            result = pangram_client.get_bulk_status("blk_123")
+
+        self.assertEqual(mock_get.call_args.args[0], f"{API_ENDPOINT}/bulk/blk_123")
+        self.assertEqual(mock_get.call_args.kwargs["headers"]["x-api-key"], "test-key")
+        self.assertEqual(result, status_response)
+
+    def test_get_bulk_items_and_results_use_pagination_params(self):
+        pangram_client = Pangram(api_key="test-key")
+        items_response = {
+            "bulk_id": "blk_123",
+            "offset": 10,
+            "limit": 25,
+            "total_items": 100,
+            "items": [],
+        }
+        results_response = {
+            "bulk_id": "blk_123",
+            "offset": 10,
+            "limit": 25,
+            "total_items": 100,
+            "items": [],
+            "failed_items": [],
+        }
+
+        with patch(
+            "pangram.text_classifier.requests.get",
+            side_effect=[
+                MockResponse(json_data=items_response),
+                MockResponse(json_data=results_response),
+            ],
+        ) as mock_get:
+            items = pangram_client.get_bulk_items("blk_123", offset=10, limit=25)
+            results = pangram_client.get_bulk_results("blk_123", offset=10, limit=25)
+
+        self.assertEqual(mock_get.call_args_list[0].args[0], f"{API_ENDPOINT}/bulk/blk_123/items")
+        self.assertEqual(mock_get.call_args_list[0].kwargs["params"], {"offset": 10, "limit": 25})
+        self.assertEqual(mock_get.call_args_list[1].args[0], f"{API_ENDPOINT}/bulk/blk_123/results")
+        self.assertEqual(mock_get.call_args_list[1].kwargs["params"], {"offset": 10, "limit": 25})
+        self.assertEqual(items, items_response)
+        self.assertEqual(results, results_response)
+
+    def test_wait_for_bulk_returns_terminal_status(self):
+        pangram_client = Pangram(api_key="test-key")
+        with patch.object(
+            PangramText,
+            "get_bulk_status",
+            side_effect=[
+                {"bulk_id": "blk_123", "status": "queued"},
+                {"bulk_id": "blk_123", "status": "running"},
+                {"bulk_id": "blk_123", "status": "partial"},
+            ],
+        ) as mock_status, patch("pangram.text_classifier.time.sleep") as mock_sleep:
+            result = pangram_client.wait_for_bulk("blk_123", timeout=10, poll_interval=0)
+
+        self.assertEqual(result["status"], "partial")
+        self.assertEqual(mock_status.call_count, 3)
+        self.assertEqual(mock_sleep.call_count, 2)
+        mock_sleep.assert_called_with(MIN_POLL_INTERVAL_SECONDS)
+
+    def test_wait_for_bulk_rejects_invalid_timeout(self):
+        pangram_client = Pangram(api_key="test-key")
+        with self.assertRaisesRegex(ValueError, "timeout must be greater than 0"):
+            pangram_client.wait_for_bulk("blk_123", timeout=0)
+
 class TestDashboard(unittest.TestCase):
     def test_dashboard(self):
         text = "hello!"

--- a/tests/pangram_test.py
+++ b/tests/pangram_test.py
@@ -273,7 +273,7 @@ class TestBulkAPI(unittest.TestCase):
         pangram_client = Pangram(api_key="test-key")
         with patch.object(
             PangramText,
-            "get_bulk_status",
+            "_fetch_bulk_status",
             side_effect=[
                 {"bulk_id": "blk_123", "status": "queued"},
                 {"bulk_id": "blk_123", "status": "running"},
@@ -286,6 +286,44 @@ class TestBulkAPI(unittest.TestCase):
         self.assertEqual(mock_status.call_count, 3)
         self.assertEqual(mock_sleep.call_count, 2)
         mock_sleep.assert_called_with(MIN_POLL_INTERVAL_SECONDS)
+
+    def test_wait_for_bulk_uses_remaining_deadline_for_poll_request_timeout(self):
+        pangram_client = Pangram(api_key="test-key")
+        terminal_response = {
+            "bulk_id": "blk_123",
+            "status": "succeeded",
+            "total_items": 1,
+            "accepted": 1,
+            "succeeded": 1,
+            "failed": 0,
+            "created_at": "1760000000.0",
+            "completed_at": "1760000001.0",
+        }
+
+        with patch(
+            "pangram.text_classifier.requests.get",
+            return_value=MockResponse(json_data=terminal_response),
+        ) as mock_get:
+            result = pangram_client.wait_for_bulk("blk_123", timeout=1, poll_interval=0)
+
+        self.assertEqual(result["status"], "succeeded")
+        self.assertLessEqual(mock_get.call_args.kwargs["timeout"], 1.0)
+
+    def test_wait_for_bulk_retries_poll_request_errors_before_deadline(self):
+        pangram_client = Pangram(api_key="test-key")
+        with patch.object(
+            PangramText,
+            "_fetch_bulk_status",
+            side_effect=[
+                requests.exceptions.ConnectionError("connection dropped"),
+                {"bulk_id": "blk_123", "status": "succeeded"},
+            ],
+        ) as mock_status, patch("pangram.text_classifier.time.sleep") as mock_sleep:
+            result = pangram_client.wait_for_bulk("blk_123", timeout=10, poll_interval=0)
+
+        self.assertEqual(result["status"], "succeeded")
+        self.assertEqual(mock_status.call_count, 2)
+        mock_sleep.assert_called_once_with(MIN_POLL_INTERVAL_SECONDS)
 
     def test_wait_for_bulk_rejects_invalid_timeout(self):
         pangram_client = Pangram(api_key="test-key")

--- a/tests/pangram_test.py
+++ b/tests/pangram_test.py
@@ -390,12 +390,17 @@ class TestDashboard(unittest.TestCase):
             return_value=MockResponse(json_data={"task_id": "task-1"}),
         ) as mock_post, patch(
             "pangram.text_classifier.requests.get",
-            return_value=MockResponse(json_data=success_response),
-        ):
-            result = pangram_client.predict_with_dashboard_link(text)
+            side_effect=[
+                MockResponse(json_data={"task_id": "task-1", "stage": "STAGE_PREPROCESSING"}),
+                MockResponse(json_data=success_response),
+            ],
+        ), patch("pangram.text_classifier.time.sleep") as mock_sleep:
+            result = pangram_client.predict_with_dashboard_link(text, timeout=1, poll_interval=0)
 
         self.assertEqual(mock_post.call_args.args[0], f"{API_ENDPOINT}/task")
         self.assertEqual(mock_post.call_args.kwargs["json"], {"text": text, "public_dashboard_link": True})
+        self.assertLessEqual(mock_post.call_args.kwargs["timeout"], 1.0)
+        mock_sleep.assert_called_once_with(MIN_POLL_INTERVAL_SECONDS)
         self.assertEqual(result, success_response)
 
 class TestPlagiarism(unittest.TestCase):

--- a/tests/pangram_test.py
+++ b/tests/pangram_test.py
@@ -234,7 +234,7 @@ class TestBulkAPI(unittest.TestCase):
         self.assertEqual(mock_get.call_args.kwargs["headers"]["x-api-key"], "test-key")
         self.assertEqual(result, status_response)
 
-    def test_get_bulk_items_and_results_use_pagination_params(self):
+    def test_get_bulk_items_and_results_page_use_pagination_params(self):
         pangram_client = Pangram(api_key="test-key")
         items_response = {
             "bulk_id": "blk_123",
@@ -260,7 +260,7 @@ class TestBulkAPI(unittest.TestCase):
             ],
         ) as mock_get:
             items = pangram_client.get_bulk_items("blk_123", offset=10, limit=25)
-            results = pangram_client.get_bulk_results("blk_123", offset=10, limit=25)
+            results = pangram_client.get_bulk_results_page("blk_123", offset=10, limit=25)
 
         self.assertEqual(mock_get.call_args_list[0].args[0], f"{API_ENDPOINT}/bulk/blk_123/items")
         self.assertEqual(mock_get.call_args_list[0].kwargs["params"], {"offset": 10, "limit": 25})
@@ -268,6 +268,50 @@ class TestBulkAPI(unittest.TestCase):
         self.assertEqual(mock_get.call_args_list[1].kwargs["params"], {"offset": 10, "limit": 25})
         self.assertEqual(items, items_response)
         self.assertEqual(results, results_response)
+
+    def test_get_bulk_results_fetches_all_pages(self):
+        pangram_client = Pangram(api_key="test-key")
+        first_page = {
+            "bulk_id": "blk_123",
+            "offset": 0,
+            "limit": 2,
+            "total_items": 3,
+            "items": [
+                {"index": 0, "id": "row-1", "task_id": "task-1", "stage": "STAGE_SUCCESS", "result": {}},
+            ],
+            "failed_items": [
+                {"index": 1, "id": "row-2", "task_id": None, "stage": "STAGE_FAILED", "error": "invalid text"},
+            ],
+        }
+        second_page = {
+            "bulk_id": "blk_123",
+            "offset": 2,
+            "limit": 2,
+            "total_items": 3,
+            "items": [
+                {"index": 2, "id": "row-3", "task_id": "task-3", "stage": "STAGE_SUCCESS", "result": {}},
+            ],
+            "failed_items": [],
+        }
+
+        with patch.object(
+            PangramText,
+            "get_bulk_results_page",
+            side_effect=[first_page, second_page],
+        ) as mock_page:
+            results = pangram_client.get_bulk_results("blk_123", page_size=2)
+
+        self.assertEqual(mock_page.call_args_list[0].kwargs, {"offset": 0, "limit": 2})
+        self.assertEqual(mock_page.call_args_list[1].kwargs, {"offset": 2, "limit": 2})
+        self.assertEqual(results["bulk_id"], "blk_123")
+        self.assertEqual(results["total_items"], 3)
+        self.assertEqual([item["index"] for item in results["items"]], [0, 2])
+        self.assertEqual([item["index"] for item in results["failed_items"]], [1])
+
+    def test_get_bulk_results_rejects_invalid_page_size(self):
+        pangram_client = Pangram(api_key="test-key")
+        with self.assertRaisesRegex(ValueError, "page_size must be between"):
+            pangram_client.get_bulk_results("blk_123", page_size=0)
 
     def test_wait_for_bulk_returns_terminal_status(self):
         pangram_client = Pangram(api_key="test-key")


### PR DESCRIPTION
Summary:
- Add Python SDK helpers for submitting, polling, inspecting, and fetching Bulk API results.
- Keep deprecated batch_predict compatibility but point users to submit_bulk for async bulk jobs.
- Bump SDK metadata to 0.3.0 and update package docs.

Tests:
- pytest
- git diff --check
- POETRY_CACHE_DIR=/private/tmp/pangram-sdk-poetry-cache poetry check