### PR TITLE
Add file upload helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,41 @@ for window in result['windows']:
 `predict()` submits to Pangram's async inference API and waits for the result before returning.
 Use `predict(text, public_dashboard_link=True)` or `predict_with_dashboard_link(text, timeout=300, poll_interval=0.5)` to include a `dashboard_link` in the completed result.
 
+### Upload files
+
+Use `predict_file()` or `predict_files()` when you want Pangram to extract text
+from `.docx`, `.pdf`, or `.rtf` documents and create AI detection results.
+Each result includes the extracted text, prediction fields, window-level
+analysis, and the uploaded `filename`. Set `public_dashboard_link=True` to
+include a `dashboard_link`.
+
+```
+from pangram import Pangram
+
+pangram_client = Pangram()
+
+result = pangram_client.predict_file(
+    "path/to/document.docx",
+    public_dashboard_link=True,
+)
+
+print(result["dashboard_link"])
+print(result["prediction_short"])
+print(result["filename"])
+```
+
+To upload multiple files in one request:
+
+```
+results = pangram_client.predict_files(
+    ["path/to/first.docx", "path/to/second.pdf"],
+    public_dashboard_link=True,
+)
+
+for result in results:
+    print(result["dashboard_link"])
+```
+
 ### Submit a Bulk API job
 
 Use the Bulk API for asynchronous AI detection across many inputs.

--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -312,6 +312,110 @@ still apply.
       "failed_items": []
     }
 
+File Upload API
+===============
+
+The File Upload API accepts one or more files as ``multipart/form-data`` and
+returns one result object per uploaded file. Use this endpoint when you want
+Pangram to extract text from ``.docx``, ``.pdf``, or ``.rtf`` documents and
+create AI detection results. Each result uses the same prediction schema as the
+text API, with the extracted ``text`` and uploaded ``filename`` included. When
+``public_dashboard_link`` is ``true``, each result also includes a
+``dashboard_link``.
+
+.. http:post:: https://file-external.api.pangram.com/
+
+  **Request Headers**
+
+  Do not set ``Content-Type`` manually for multipart requests. HTTP clients add
+  the multipart boundary automatically.
+
+  .. code-block:: json
+
+    {
+      "x-api-key": "<api-key>"
+    }
+
+  **Multipart Form Fields**
+
+  .. list-table::
+     :header-rows: 1
+
+     * - Field
+       - Type
+       - Required
+       - Description
+     * - ``files``
+       - file[]
+       - Yes
+       - ``.docx``, ``.pdf``, or ``.rtf`` files to analyze. Include this form field once per uploaded file.
+     * - ``public_dashboard_link``
+       - boolean
+       - No
+       - Whether to create and return a ``dashboard_link`` for each uploaded file. Defaults to ``false``.
+
+  **Example Request**
+
+  .. code-block:: http
+
+    POST https://file-external.api.pangram.com/ HTTP/1.1
+    x-api-key: your_api_key_here
+    Content-Type: multipart/form-data; boundary=...
+
+    --...
+    Content-Disposition: form-data; name="files"; filename="document.docx"
+    Content-Type: application/octet-stream
+
+    <file bytes>
+    --...
+    Content-Disposition: form-data; name="public_dashboard_link"
+
+    true
+    --...--
+
+  **Example cURL**
+
+  .. code-block:: bash
+
+    curl -s -X POST https://file-external.api.pangram.com \
+      -H "x-api-key: $PANGRAM_API_KEY" \
+      -F "files=@path/to/first.docx" \
+      -F "files=@path/to/second.pdf" \
+      -F "public_dashboard_link=true"
+
+  **Example Response**
+
+  .. code-block:: json
+
+    [
+      {
+        "filename": "document.docx",
+        "text": "Extracted document text...",
+        "version": "3.3",
+        "headline": "Human Written",
+        "prediction": "We believe this is human-written",
+        "prediction_short": "Human",
+        "fraction_ai": 0.0,
+        "fraction_ai_assisted": 0.0,
+        "fraction_human": 1.0,
+        "num_ai_segments": 0,
+        "num_ai_assisted_segments": 0,
+        "num_human_segments": 1,
+        "windows": [],
+        "dashboard_link": "https://www.pangram.com/history/123e4567-e89b-12d3-a456-426614174000"
+      }
+    ]
+
+  **Errors**
+
+  - ``400 Bad Request`` - The multipart request is missing a file or includes invalid form data.
+  - ``401 Unauthorized`` - The ``x-api-key`` is missing or invalid.
+  - ``402 Payment Required`` - The account has insufficient credits.
+  - ``413 Payload Too Large`` - The upload exceeds the maximum supported file size.
+  - ``415 Unsupported Media Type`` - The uploaded file type is not supported.
+  - ``422 Unprocessable Entity`` - The ``files`` field is missing, the form data is invalid, or Pangram could not extract valid text from the uploaded file.
+  - ``500 Internal Server Error`` - There was an error processing the upload.
+
 Plagiarism Detection API
 ========================
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -56,6 +56,41 @@ The SDK submits to Pangram's async inference API and waits for the completed res
         ai_assistance_score = window['ai_assistance_score']
         confidence = window['confidence']
 
+Upload files
+~~~~~~~~~~~~
+Use ``predict_file()`` or ``predict_files()`` when you want Pangram to extract
+text from ``.docx``, ``.pdf``, or ``.rtf`` documents and create AI detection
+results. Each result includes the extracted text, prediction fields,
+window-level analysis, and the uploaded ``filename``. Set
+``public_dashboard_link=True`` to include a ``dashboard_link``.
+
+.. code:: python
+
+    from pangram import Pangram
+
+    pangram_client = Pangram()
+
+    result = pangram_client.predict_file(
+        "path/to/document.docx",
+        public_dashboard_link=True,
+    )
+
+    print(result["dashboard_link"])
+    print(result["prediction_short"])
+    print(result["filename"])
+
+To upload multiple files in one request:
+
+.. code:: python
+
+    results = pangram_client.predict_files(
+        ["path/to/first.docx", "path/to/second.pdf"],
+        public_dashboard_link=True,
+    )
+
+    for result in results:
+        print(result["dashboard_link"])
+
 Submit a Bulk API job
 ~~~~~~~~~~~~~~~~~~~~~
 Use the Bulk API for asynchronous AI detection across many inputs. Submit either

--- a/pangram/__init__.py
+++ b/pangram/__init__.py
@@ -1,5 +1,5 @@
 """Defile all variables to be accessible from `import pangram`."""
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 __author__ = "Max Spero"
 __email__ = "max@pangram.com"
 __license__ = "MIT"

--- a/pangram/text_classifier.py
+++ b/pangram/text_classifier.py
@@ -4,7 +4,7 @@ import time
 import warnings
 from typing import List, Dict, Optional, Tuple, Union
 
-SOURCE_VERSION = "python_sdk_0.3.0"
+SOURCE_VERSION = "python_sdk_0.3.1"
 
 API_ENDPOINT = 'https://text.external-api.pangram.com'
 FILE_UPLOAD_API_ENDPOINT = 'https://file-external.api.pangram.com'

--- a/pangram/text_classifier.py
+++ b/pangram/text_classifier.py
@@ -2,11 +2,12 @@ import requests
 import os
 import time
 import warnings
-from typing import List, Dict, Optional, Tuple
+from typing import List, Dict, Optional, Tuple, Union
 
 SOURCE_VERSION = "python_sdk_0.3.0"
 
 API_ENDPOINT = 'https://text.external-api.pangram.com'
+FILE_UPLOAD_API_ENDPOINT = 'https://file-external.api.pangram.com'
 PLAGIARISM_API_ENDPOINT = 'https://plagiarism.api.pangram.com'
 ASYNC_SUCCESS_STAGE = 'STAGE_SUCCESS'
 ASYNC_FAILED_STAGE = 'STAGE_FAILED'
@@ -34,10 +35,15 @@ class PangramText:
         if self.api_key is None:
             raise ValueError("API key is required. Set the environment variable PANGRAM_API_KEY or pass it as an argument to PangramText.")
 
+    def _auth_headers(self) -> Dict[str, str]:
+        return {
+            'x-api-key': self.api_key,
+        }
+
     def _headers(self) -> Dict[str, str]:
         return {
             'Content-Type': 'application/json',
-            'x-api-key': self.api_key,
+            **self._auth_headers(),
         }
 
     def _request_timeout(self, deadline: float) -> float:
@@ -426,6 +432,98 @@ class PangramText:
             timeout,
             max(MIN_POLL_INTERVAL_SECONDS, poll_interval),
         )
+
+    def predict_files(
+        self,
+        file_paths: List[Union[str, os.PathLike]],
+        public_dashboard_link: bool = False,
+        timeout: float = DEFAULT_PREDICT_TIMEOUT_SECONDS,
+    ) -> List[Dict]:
+        """
+        Upload one or more files for AI detection.
+
+        Files are submitted to Pangram's file upload endpoint as multipart form
+        data with one ``files`` field per uploaded .docx, .pdf, or .rtf file.
+        Each returned result includes the extracted text, prediction fields,
+        window-level analysis, and the uploaded ``filename``. When
+        ``public_dashboard_link`` is true, each result also includes a
+        ``dashboard_link`` URL.
+
+        :param file_paths: Paths to files to upload and analyze.
+        :type file_paths: List[Union[str, os.PathLike]]
+        :param public_dashboard_link: Whether to create public dashboard links for the uploaded files. Defaults to False.
+        :type public_dashboard_link: bool
+        :param timeout: Maximum seconds to wait for the upload request to complete. Defaults to 300.
+        :type timeout: float
+        :return: A list of per-file result dictionaries returned by the API.
+        :rtype: List[Dict]
+        :raises ValueError: If no files are provided, if timeout is invalid, if
+                            the API returns an error, or if the response is invalid.
+        :raises requests.RequestException: File open errors are raised by Python before the request is sent.
+        """
+        if not file_paths:
+            raise ValueError("file_paths must contain at least one file")
+        if timeout <= 0:
+            raise ValueError("timeout must be greater than 0")
+
+        opened_files = []
+        files_payload = []
+        try:
+            for file_path in file_paths:
+                path = os.fspath(file_path)
+                file_obj = open(path, "rb")
+                opened_files.append(file_obj)
+                files_payload.append(("files", (os.path.basename(path), file_obj)))
+
+            try:
+                response = requests.post(
+                    FILE_UPLOAD_API_ENDPOINT,
+                    files=files_payload,
+                    data={"public_dashboard_link": str(public_dashboard_link).lower()},
+                    headers=self._auth_headers(),
+                    timeout=timeout,
+                )
+            except requests.RequestException as exc:
+                raise ValueError(f"Pangram API request failed while uploading files: {exc}") from exc
+
+            response_json = self._parse_response_json(response)
+            if not isinstance(response_json, list):
+                raise ValueError(f"Error returned by API: invalid file upload response: {response_json}")
+            return response_json
+        finally:
+            for file_obj in opened_files:
+                file_obj.close()
+
+    def predict_file(
+        self,
+        file_path: Union[str, os.PathLike],
+        public_dashboard_link: bool = False,
+        timeout: float = DEFAULT_PREDICT_TIMEOUT_SECONDS,
+    ) -> Dict:
+        """
+        Upload a single file for AI detection.
+
+        This convenience method calls :meth:`predict_files` with one path and
+        returns the first per-file result.
+
+        :param file_path: Path to the file to upload and analyze.
+        :type file_path: Union[str, os.PathLike]
+        :param public_dashboard_link: Whether to create a public dashboard link for the uploaded file. Defaults to False.
+        :type public_dashboard_link: bool
+        :param timeout: Maximum seconds to wait for the upload request to complete. Defaults to 300.
+        :type timeout: float
+        :return: The per-file result dictionary returned by the API.
+        :rtype: Dict
+        :raises ValueError: If the API returns an error or an invalid response.
+        """
+        response_json = self.predict_files(
+            [file_path],
+            public_dashboard_link=public_dashboard_link,
+            timeout=timeout,
+        )
+        if not response_json:
+            raise ValueError("Error returned by API: empty file upload response")
+        return response_json[0]
 
 
     def predict_short(self, text: str) -> Dict:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pangram-sdk"
-version = "0.3.0"
+version = "0.3.1"
 description = ""
 authors = ["Max Spero <max@pangramlabs.com>"]
 readme = "README.md"

--- a/tests/pangram_test.py
+++ b/tests/pangram_test.py
@@ -1,8 +1,9 @@
 import unittest
 import requests
 from pangram import Pangram, PangramText
-from pangram.text_classifier import API_ENDPOINT, MIN_POLL_INTERVAL_SECONDS
+from pangram.text_classifier import API_ENDPOINT, FILE_UPLOAD_API_ENDPOINT, MIN_POLL_INTERVAL_SECONDS
 import os
+import tempfile
 from unittest.mock import patch
 
 
@@ -402,6 +403,98 @@ class TestDashboard(unittest.TestCase):
         self.assertLessEqual(mock_post.call_args.kwargs["timeout"], 1.0)
         mock_sleep.assert_called_once_with(MIN_POLL_INTERVAL_SECONDS)
         self.assertEqual(result, success_response)
+
+class TestFileUpload(unittest.TestCase):
+    def _write_test_file(self, directory, name):
+        path = os.path.join(directory, name)
+        with open(path, "wb") as file_obj:
+            file_obj.write(b"test file contents")
+        return path
+
+    def test_predict_file_uploads_multipart_file(self):
+        pangram_client = Pangram(api_key="test-key")
+        upload_response = [
+            {"dashboard_link": "https://www.pangram.com/history/query-1"}
+        ]
+
+        with tempfile.TemporaryDirectory() as directory:
+            file_path = self._write_test_file(directory, "document.docx")
+            with patch(
+                "pangram.text_classifier.requests.post",
+                return_value=MockResponse(json_data=upload_response),
+            ) as mock_post:
+                result = pangram_client.predict_file(
+                    file_path,
+                    public_dashboard_link=True,
+                    timeout=12,
+                )
+
+        self.assertEqual(mock_post.call_args.args[0], FILE_UPLOAD_API_ENDPOINT)
+        self.assertEqual(mock_post.call_args.kwargs["data"], {"public_dashboard_link": "true"})
+        self.assertEqual(mock_post.call_args.kwargs["headers"], {"x-api-key": "test-key"})
+        self.assertEqual(mock_post.call_args.kwargs["timeout"], 12)
+        files = mock_post.call_args.kwargs["files"]
+        self.assertEqual(len(files), 1)
+        self.assertEqual(files[0][0], "files")
+        self.assertEqual(files[0][1][0], "document.docx")
+        self.assertTrue(files[0][1][1].closed)
+        self.assertEqual(result, upload_response[0])
+
+    def test_predict_files_repeats_files_form_field(self):
+        pangram_client = Pangram(api_key="test-key")
+        upload_response = [
+            {"dashboard_link": "https://www.pangram.com/history/query-1"},
+            {"dashboard_link": "https://www.pangram.com/history/query-2"},
+        ]
+
+        with tempfile.TemporaryDirectory() as directory:
+            first_path = self._write_test_file(directory, "first.pdf")
+            second_path = self._write_test_file(directory, "second.rtf")
+            with patch(
+                "pangram.text_classifier.requests.post",
+                return_value=MockResponse(json_data=upload_response),
+            ) as mock_post:
+                result = pangram_client.predict_files([first_path, second_path])
+
+        self.assertEqual(mock_post.call_args.kwargs["data"], {"public_dashboard_link": "false"})
+        files = mock_post.call_args.kwargs["files"]
+        self.assertEqual([file_item[0] for file_item in files], ["files", "files"])
+        self.assertEqual([file_item[1][0] for file_item in files], ["first.pdf", "second.rtf"])
+        self.assertEqual(result, upload_response)
+
+    def test_predict_files_requires_at_least_one_file(self):
+        pangram_client = Pangram(api_key="test-key")
+        with self.assertRaisesRegex(ValueError, "at least one file"):
+            pangram_client.predict_files([])
+
+    def test_predict_files_rejects_invalid_timeout(self):
+        pangram_client = Pangram(api_key="test-key")
+        with tempfile.TemporaryDirectory() as directory:
+            file_path = self._write_test_file(directory, "document.docx")
+            with self.assertRaisesRegex(ValueError, "timeout must be greater than 0"):
+                pangram_client.predict_file(file_path, timeout=0)
+
+    def test_predict_files_wraps_request_errors(self):
+        pangram_client = Pangram(api_key="test-key")
+        with tempfile.TemporaryDirectory() as directory:
+            file_path = self._write_test_file(directory, "document.docx")
+            with patch(
+                "pangram.text_classifier.requests.post",
+                side_effect=requests.exceptions.Timeout("timed out"),
+            ):
+                with self.assertRaisesRegex(ValueError, "uploading files: timed out"):
+                    pangram_client.predict_file(file_path)
+
+    def test_predict_files_rejects_invalid_response_shape(self):
+        pangram_client = Pangram(api_key="test-key")
+        with tempfile.TemporaryDirectory() as directory:
+            file_path = self._write_test_file(directory, "document.docx")
+            with patch(
+                "pangram.text_classifier.requests.post",
+                return_value=MockResponse(json_data={"unexpected": "shape"}),
+            ):
+                with self.assertRaisesRegex(ValueError, "invalid file upload response"):
+                    pangram_client.predict_file(file_path)
 
 class TestPlagiarism(unittest.TestCase):
     @unittest.skipUnless(os.getenv('PANGRAM_API_KEY'), "requires PANGRAM_API_KEY")


### PR DESCRIPTION
Summary: Adds Pangram.predict_file() and Pangram.predict_files() for multipart document uploads; documents supported .docx, .pdf, and .rtf uploads plus the dashboard_link response; adds unit coverage for multipart request construction and error handling. Tests: pytest -q.